### PR TITLE
Bump egglog version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "add_primitive"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d2fa5b7#d2fa5b733de0796fb187dc5a27e570d5644aa75a"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=5542549#55425498b92bab18fcf3ea35224e42e2ad0afff6"
 dependencies = [
  "quote",
  "syn 2.0.102",
@@ -288,7 +288,7 @@ dependencies = [
 [[package]]
 name = "concurrency"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=1a1f913#1a1f913e88101dbd6f98cc2468be0f0d1b87960b"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=cd51d04#cd51d048f9ef8e0bd9eac2966c35e054ac5c8368"
 dependencies = [
  "arc-swap",
  "rayon",
@@ -297,7 +297,7 @@ dependencies = [
 [[package]]
 name = "core-relations"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=1a1f913#1a1f913e88101dbd6f98cc2468be0f0d1b87960b"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=cd51d04#cd51d048f9ef8e0bd9eac2966c35e054ac5c8368"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -462,7 +462,7 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 [[package]]
 name = "egglog"
 version = "0.5.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d2fa5b7#d2fa5b733de0796fb187dc5a27e570d5644aa75a"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=5542549#55425498b92bab18fcf3ea35224e42e2ad0afff6"
 dependencies = [
  "add_primitive",
  "chrono",
@@ -488,7 +488,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=1a1f913#1a1f913e88101dbd6f98cc2468be0f0d1b87960b"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=cd51d04#cd51d048f9ef8e0bd9eac2966c35e054ac5c8368"
 dependencies = [
  "anyhow",
  "core-relations",
@@ -967,7 +967,7 @@ dependencies = [
 [[package]]
 name = "numeric-id"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=1a1f913#1a1f913e88101dbd6f98cc2468be0f0d1b87960b"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=cd51d04#cd51d048f9ef8e0bd9eac2966c35e054ac5c8368"
 dependencies = [
  "lazy_static",
  "rayon",
@@ -1481,7 +1481,7 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 [[package]]
 name = "union-find"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=1a1f913#1a1f913e88101dbd6f98cc2468be0f0d1b87960b"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=cd51d04#cd51d048f9ef8e0bd9eac2966c35e054ac5c8368"
 dependencies = [
  "concurrency",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ harness = false
 name = "files"
 
 [dependencies]
-egglog = { git = "https://github.com/egraphs-good/egglog.git", rev = "d2fa5b7" }
+egglog = { git = "https://github.com/egraphs-good/egglog.git", rev = "5542549" }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use egglog::prelude::add_leaf_sort;
+use egglog::prelude::add_base_sort;
 pub use egglog::*;
 use std::sync::Arc;
 
@@ -14,7 +14,7 @@ pub use set_cost::*;
 
 pub fn new_experimental_egraph() -> EGraph {
     let mut egraph = EGraph::default();
-    add_leaf_sort(&mut egraph, RationalSort, span!()).unwrap();
+    add_base_sort(&mut egraph, RationalSort, span!()).unwrap();
     egraph.parser.add_command_macro(Arc::new(For));
     egraph.parser.add_command_macro(Arc::new(WithRuleset));
 


### PR DESCRIPTION
* Update function name for adding base sort
* Changes cost model to be u64 (DefaultCost) instead of usize to match tree cost model