### PR TITLE
Update egglog dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,8 @@ version = 4
 
 [[package]]
 name = "add_primitive"
-version = "0.1.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=afe962958b57b6101f3f48e980f910fa063f3f6e#afe962958b57b6101f3f48e980f910fa063f3f6e"
+version = "1.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=0be495630546acffbd545ba60feb9302281ce95c#0be495630546acffbd545ba60feb9302281ce95c"
 dependencies = [
  "quote",
  "syn 2.0.102",
@@ -296,8 +296,8 @@ dependencies = [
 
 [[package]]
 name = "concurrency"
-version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=cd51d04#cd51d048f9ef8e0bd9eac2966c35e054ac5c8368"
+version = "1.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=0be495630546acffbd545ba60feb9302281ce95c#0be495630546acffbd545ba60feb9302281ce95c"
 dependencies = [
  "arc-swap",
  "rayon",
@@ -305,8 +305,8 @@ dependencies = [
 
 [[package]]
 name = "core-relations"
-version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=cd51d04#cd51d048f9ef8e0bd9eac2966c35e054ac5c8368"
+version = "1.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=0be495630546acffbd545ba60feb9302281ce95c#0be495630546acffbd545ba60feb9302281ce95c"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -470,8 +470,8 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "egglog"
-version = "0.5.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=afe962958b57b6101f3f48e980f910fa063f3f6e#afe962958b57b6101f3f48e980f910fa063f3f6e"
+version = "1.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=0be495630546acffbd545ba60feb9302281ce95c#0be495630546acffbd545ba60feb9302281ce95c"
 dependencies = [
  "add_primitive",
  "chrono",
@@ -498,8 +498,8 @@ dependencies = [
 
 [[package]]
 name = "egglog-bridge"
-version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=cd51d04#cd51d048f9ef8e0bd9eac2966c35e054ac5c8368"
+version = "1.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=0be495630546acffbd545ba60feb9302281ce95c#0be495630546acffbd545ba60feb9302281ce95c"
 dependencies = [
  "anyhow",
  "core-relations",
@@ -996,8 +996,8 @@ dependencies = [
 
 [[package]]
 name = "numeric-id"
-version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=cd51d04#cd51d048f9ef8e0bd9eac2966c35e054ac5c8368"
+version = "1.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=0be495630546acffbd545ba60feb9302281ce95c#0be495630546acffbd545ba60feb9302281ce95c"
 dependencies = [
  "lazy_static",
  "rayon",
@@ -1516,8 +1516,8 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "union-find"
-version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=cd51d04#cd51d048f9ef8e0bd9eac2966c35e054ac5c8368"
+version = "1.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=0be495630546acffbd545ba60feb9302281ce95c#0be495630546acffbd545ba60feb9302281ce95c"
 dependencies = [
  "concurrency",
  "crossbeam",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "add_primitive"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=5542549#55425498b92bab18fcf3ea35224e42e2ad0afff6"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=afe962958b57b6101f3f48e980f910fa063f3f6e#afe962958b57b6101f3f48e980f910fa063f3f6e"
 dependencies = [
  "quote",
  "syn 2.0.102",
@@ -135,6 +135,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -462,7 +471,7 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 [[package]]
 name = "egglog"
 version = "0.5.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=5542549#55425498b92bab18fcf3ea35224e42e2ad0afff6"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=afe962958b57b6101f3f48e980f910fa063f3f6e#afe962958b57b6101f3f48e980f910fa063f3f6e"
 dependencies = [
  "add_primitive",
  "chrono",
@@ -477,9 +486,11 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "log",
+ "mimalloc",
  "num",
  "numeric-id",
  "ordered-float",
+ "rayon",
  "rustc-hash",
  "thiserror 2.0.12",
  "web-time",
@@ -843,6 +854,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88cd67e9de251c1781dbe2f641a1a3ad66eaae831b8a2c38fbdc5ddae16d4d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libtest-mimic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,6 +901,15 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1791cbe101e95af5764f06f20f6760521f7158f69dbf9d6baf941ee1bf6bc40"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "num"
@@ -1334,6 +1364,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sized-chunks"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ harness = false
 name = "files"
 
 [dependencies]
-egglog = { git = "https://github.com/egraphs-good/egglog.git", rev = "5542549" }
+egglog = { git = "https://github.com/saulshanabrook/egg-smol.git", rev = "afe962958b57b6101f3f48e980f910fa063f3f6e" }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ harness = false
 name = "files"
 
 [dependencies]
-egglog = { git = "https://github.com/saulshanabrook/egg-smol.git", rev = "afe962958b57b6101f3f48e980f910fa063f3f6e" }
+egglog = { git = "https://github.com/egraphs-good/egglog.git", rev = "0be495630546acffbd545ba60feb9302281ce95c" }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
+use std::{collections::HashMap, sync::Mutex};
 
 use egglog::{
     ast::{Expr, Fact, Facts, Literal, ParseError},
@@ -199,21 +196,6 @@ impl ScheduleState {
     }
 }
 
-#[derive(Debug, Clone)]
-struct RunExtendedScheduleOutput {
-    reports: Vec<RunReport>,
-}
-
-impl std::fmt::Display for RunExtendedScheduleOutput {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Ran schedules:")?;
-        for report in &self.reports {
-            writeln!(f, "{}", report)?;
-        }
-        Ok(())
-    }
-}
-
 impl UserDefinedCommand for RunExtendedSchedule {
     fn update(
         &self,
@@ -221,13 +203,11 @@ impl UserDefinedCommand for RunExtendedSchedule {
         args: &[Expr],
     ) -> Result<Option<CommandOutput>, egglog::Error> {
         let mut schedule = ScheduleState::new();
-        let mut reports = Vec::new();
+        let mut report = RunReport::default();
         for arg in args {
-            reports.push(schedule.run(egraph, arg)?);
+            report.union(schedule.run(egraph, arg)?);
         }
-        Ok(Some(CommandOutput::UserDefined(Arc::new(
-            RunExtendedScheduleOutput { reports },
-        ))))
+        Ok(Some(CommandOutput::RunSchedule(report)))
     }
 }
 

--- a/src/set_cost.rs
+++ b/src/set_cost.rs
@@ -4,8 +4,9 @@ use egglog::{
     ast::*,
     extract::{CostModel, DefaultCost, Extractor, TreeAdditiveCostModel},
     util::FreshGen,
-    EGraph, Error, Term, TermDag, TypeError, UserDefinedCommand,
+    CommandOutput, EGraph, Error, Term, TermDag, TypeError, UserDefinedCommand,
 };
+use log::log_enabled;
 
 pub fn add_set_cost(egraph: &mut EGraph) {
     egraph
@@ -208,7 +209,11 @@ impl CostModel<DefaultCost> for DynamicCostModel {
 struct CustomExtract;
 
 impl UserDefinedCommand for CustomExtract {
-    fn update(&self, egraph: &mut EGraph, args: &[Expr]) -> Result<(), Error> {
+    fn update(
+        &self,
+        egraph: &mut EGraph,
+        args: &[Expr],
+    ) -> Result<Option<CommandOutput>, egglog::Error> {
         assert!(args.len() <= 2);
         let (sort, value) = egraph.eval_expr(&args[0])?;
         let n = args.get(1).map(|arg| egraph.eval_expr(arg)).transpose()?;
@@ -236,26 +241,15 @@ impl UserDefinedCommand for CustomExtract {
         );
         if n == 0 {
             if let Some((cost, term)) = extractor.extract_best(egraph, &mut termdag, value) {
-                // dont turn termdag into a string if we have messages disabled for performance reasons
-                if egraph.messages_enabled() {
-                    let extracted = termdag.to_string(&term);
-                    log::info!("extracted with cost {cost}: {extracted}");
-                    egraph.print_msg(extracted);
+                if log_enabled!(log::Level::Info) {
+                    log::info!("extracted with cost {cost}: {}", termdag.to_string(&term));
                 }
-                // TODO: egraph.extract_report is private
-                // A future implementation should make a egglog_experimental::EGraph
-                // that provides a similar set of methods and overrides its own extract_report.
-                //
-                // egraph.extract_report = Some(ExtractReport::Best {
-                //     termdag,
-                //     cost,
-                //     term,
-                // });
+                Ok(Some(CommandOutput::ExtractBest(termdag, cost, term)))
             } else {
-                return Err(Error::ExtractError(
+                Err(Error::ExtractError(
                     "Unable to find any valid extraction (likely due to subsume or delete)"
                         .to_string(),
-                ));
+                ))
             }
         } else {
             if n < 0 {
@@ -266,24 +260,8 @@ impl UserDefinedCommand for CustomExtract {
                 .iter()
                 .map(|e| e.1.clone())
                 .collect();
-            // Same as above, avoid turning termdag into a string if we have messages disabled for performance
-            if egraph.messages_enabled() {
-                log::info!("extracted variants:");
-                let mut msg = String::default();
-                msg += "(\n";
-                assert!(!terms.is_empty());
-                for expr in &terms {
-                    let str = termdag.to_string(expr);
-                    log::info!("   {str}");
-                    msg += &format!("   {str}\n");
-                }
-                msg += ")";
-                egraph.print_msg(msg);
-            }
-            // TODO: Same as above. EGraph::extract_report is private.
-            //
-            // egraph.extract_report = Some(ExtractReport::Variants { termdag, terms });
+            log::info!("extracted variants:");
+            Ok(Some(CommandOutput::ExtractVariants(termdag, terms)))
         }
-        Ok(())
     }
 }

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -53,11 +53,13 @@ impl Run {
                         print!("  {}", output);
                     }
                     // Test graphviz dot generation
-                    let mut serialized = egraph.serialize(SerializeConfig {
-                        max_functions: Some(40),
-                        max_calls_per_function: Some(40),
-                        ..Default::default()
-                    });
+                    let mut serialized = egraph
+                        .serialize(SerializeConfig {
+                            max_functions: Some(40),
+                            max_calls_per_function: Some(40),
+                            ..Default::default()
+                        })
+                        .egraph;
                     serialized.to_dot();
                     // Also try splitting and inlining
                     serialized.split_classes(|id, _| egraph.from_node_id(id).is_primitive());

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -22,9 +22,8 @@ impl Run {
             );
         } else {
             let mut egraph = new_experimental_egraph();
-            egraph.run_mode = RunMode::ShowDesugaredEgglog;
             let desugared_str = egraph
-                .parse_and_run_program(self.path.to_str().map(String::from), &program)
+                .resugar_program(self.path.to_str().map(String::from), &program)
                 .unwrap()
                 .join("\n");
 
@@ -39,15 +38,19 @@ impl Run {
     fn test_program(&self, filename: Option<String>, program: &str, message: &str) {
         let mut egraph = new_experimental_egraph();
         match egraph.parse_and_run_program(filename, program) {
-            Ok(msgs) => {
+            Ok(outputs) => {
                 if self.should_fail() {
                     panic!(
                         "Program should have failed! Instead, logged:\n {}",
-                        msgs.join("\n")
+                        outputs
+                            .iter()
+                            .map(|output| output.to_string())
+                            .collect::<Vec<_>>()
+                            .join("\n")
                     );
                 } else {
-                    for msg in msgs {
-                        println!("  {}", msg);
+                    for output in outputs {
+                        print!("  {}", output);
                     }
                     // Test graphviz dot generation
                     let mut serialized = egraph.serialize(SerializeConfig {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -35,11 +35,11 @@ fn test_extract() {
         .unwrap();
 
     assert_eq!(result.len(), 5);
-    assert_eq!(result[0], "(Add (Num 1) (Num 1))");
-    assert_eq!(result[1], "(Num 2)");
-    assert_eq!(result[2], "(Add (Num 1) (Num 1))");
-    assert_eq!(result[3], "(Add (Num 1) (Num 1))");
-    assert_eq!(result[4], "(Sub (Num 5) (Num 3))");
+    assert_eq!(result[0].to_string(), "(Add (Num 1) (Num 1))\n");
+    assert_eq!(result[1].to_string(), "(Num 2)\n");
+    assert_eq!(result[2].to_string(), "(Add (Num 1) (Num 1))\n");
+    assert_eq!(result[3].to_string(), "(Add (Num 1) (Num 1))\n");
+    assert_eq!(result[4].to_string(), "(Sub (Num 5) (Num 3))\n");
 }
 
 #[test]
@@ -74,7 +74,7 @@ fn test_extract_set_cost_decls() {
             "(with-dynamic-cost
                 (datatype E (Add E E) (Sub E E :cost 200) (Num i64))
                 (constructor Mul (E E) E :cost 100)
-                (datatype* 
+                (datatype*
                   (E2 (Add2 E2 E2) (Sub2 E2 E2 :cost 200) (List VecE2) (Num2 i64))
                   (sort VecE2 (Vec E2))
                 )


### PR DESCRIPTION
Adds support for structured output added in https://github.com/egraphs-good/egglog/pull/653.

This also lets us get the result of running extract with the new custom cost model from Python. 

~~Adds a custom output for running schedules to return all reports and print them all. I wasn't sure if this was the right output, but I wanted to add one to demonstrate that it's possible.~~ Changed to have the custom scheduler return the same output as the default scheduler to have the same output and be handled the same by the Python bindings.