### PR TITLE
Fix cost values in integration_test.rs

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -16,12 +16,12 @@ fn test_extract() {
         (extract (Num 2))
 
         (push)
-        (set-cost (Add (Num 1) (Num 1)) 801)
+        (set-cost (Add (Num 1) (Num 1)) 800)
         (extract (Num 2))
         (pop)
 
         (push)
-        (set-cost (Add (Num 1) (Num 1)) 799)
+        (set-cost (Add (Num 1) (Num 1)) 798)
         (extract (Num 2))
         (pop)
 


### PR DESCRIPTION
Fixed cost values for Add operations in integration tests.

I noticed when translating this to Python that the current tests, while passing currently, have costs that are equal when extracting so that if things are added in another order the result will not be consistent.

This PR fixes the costs so that the value returned should be deterministic based on the costs.