### PR TITLE
Use can_stop for experimental saturation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-can-stop-report#ebba7bb902bdc1b0f377b6bb22c06ac305912674"
 dependencies = [
  "chrono",
  "clap",
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-can-stop-report#ebba7bb902bdc1b0f377b6bb22c06ac305912674"
 dependencies = [
  "quote",
  "syn 2.0.108",
@@ -371,7 +371,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-can-stop-report#ebba7bb902bdc1b0f377b6bb22c06ac305912674"
 dependencies = [
  "ordered-float",
 ]
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-can-stop-report#ebba7bb902bdc1b0f377b6bb22c06ac305912674"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -402,7 +402,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-can-stop-report#ebba7bb902bdc1b0f377b6bb22c06ac305912674"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-can-stop-report#ebba7bb902bdc1b0f377b6bb22c06ac305912674"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -457,7 +457,7 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-can-stop-report#ebba7bb902bdc1b0f377b6bb22c06ac305912674"
 dependencies = [
  "rayon",
 ]
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "egglog-reports"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-can-stop-report#ebba7bb902bdc1b0f377b6bb22c06ac305912674"
 dependencies = [
  "clap",
  "hashbrown 0.16.0",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-can-stop-report#ebba7bb902bdc1b0f377b6bb22c06ac305912674"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { git = "https://github.com/egraphs-good/egglog.git", rev = "d330f2c632adc5d2ef7e4cfc51286ba0ed241721", default-features = false }
-egglog-ast = { git = "https://github.com/egraphs-good/egglog.git", rev = "d330f2c632adc5d2ef7e4cfc51286ba0ed241721", default-features = false }
-egglog-reports = { git = "https://github.com/egraphs-good/egglog.git", rev = "d330f2c632adc5d2ef7e4cfc51286ba0ed241721", default-features = false }
+egglog = { git = "https://github.com/saulshanabrook/egg-smol.git", branch = "codex/split-scheduler-can-stop-report", default-features = false }
+egglog-ast = { git = "https://github.com/saulshanabrook/egg-smol.git", branch = "codex/split-scheduler-can-stop-report", default-features = false }
+egglog-reports = { git = "https://github.com/saulshanabrook/egg-smol.git", branch = "codex/split-scheduler-can-stop-report", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -150,10 +150,11 @@ impl ScheduleState {
                         }
                         Ok(iter_report)
                     })?;
-                    if !iter_report.updated {
+                    let should_stop = iter_report.can_stop;
+                    report.union(iter_report);
+                    if should_stop {
                         break;
                     }
-                    report.union(iter_report);
                 }
                 Ok(report)
             }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use egglog::{
+    CommandOutput,
     ast::{Expr, Literal},
     prelude::{RustSpan, Span},
 };
@@ -236,4 +237,85 @@ fn test_multi_extract_with_set_cost() {
     assert!(output.contains("(Add (Num 5) (Num 5))"));
     assert!(output.contains("(Add (Num 3) (Num 3))"));
     assert!(!output.contains("Mul"));
+}
+
+fn add_copy_backoff_program(egraph: &mut egglog::EGraph) {
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (ruleset copy)
+        (relation R (i64))
+        (relation S (i64))
+        (R 0)
+        (R 1)
+        (R 2)
+        (R 3)
+        (rule ((R x)) ((S x)) :ruleset copy :name "copy")
+        "#,
+        )
+        .unwrap();
+}
+
+fn only_run_report(outputs: &[CommandOutput]) -> &egglog_reports::RunReport {
+    match outputs {
+        [CommandOutput::RunSchedule(report)] => report,
+        other => panic!("expected one RunSchedule output, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_backoff_run_schedule_should_not_report_progress_without_egraph_updates() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+    add_copy_backoff_program(&mut egraph);
+
+    let outputs = egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (run-schedule
+          (let-scheduler bo (back-off :match-limit 1 :ban-length 3))
+          (run-with bo copy))
+        "#,
+        )
+        .unwrap();
+
+    let report = only_run_report(&outputs);
+    assert_eq!(egraph.get_size("S"), 0);
+    assert!(
+        !report.updated,
+        "banning work in the scheduler is not database progress"
+    );
+    assert!(
+        !report.can_stop,
+        "the scheduler still has deferred work after the ban"
+    );
+}
+
+#[test]
+fn test_saturate_continues_until_scheduler_can_stop_after_no_progress_ban() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+    add_copy_backoff_program(&mut egraph);
+
+    let outputs = egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (run-schedule
+          (let-scheduler bo (back-off :match-limit 1 :ban-length 3))
+          (saturate (run-with bo copy)))
+        "#,
+        )
+        .unwrap();
+
+    let report = only_run_report(&outputs);
+    assert_eq!(
+        egraph.get_size("S"),
+        4,
+        "saturate should keep running while the scheduler reports deferred work"
+    );
+    assert!(
+        report.updated,
+        "the eventual copy applications should be reported as database progress"
+    );
 }


### PR DESCRIPTION
## Context

Experimental saturation needs to continue while a scheduler reports deferred work, even when a step does not change the database. This uses the new egglog `RunReport::can_stop` field.

Depends on: https://github.com/egraphs-good/egglog/pull/882

## Changes

- Uses `RunReport::can_stop` as the saturation break condition.
- Keeps scheduler-only deferred work separate from database update reporting.
- Adds tests showing back-off scheduling reports no database progress while still requiring saturation to continue.

## Validation

- `cargo test --test integration_test can_stop`
- `cargo fmt`
- `git diff --check`
