### PR TITLE
Add back-off-fresh scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-fresh-rematch#1b83c1fce51cd49dfdcb724686c65e8d9485ba8f"
 dependencies = [
  "chrono",
  "clap",
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-fresh-rematch#1b83c1fce51cd49dfdcb724686c65e8d9485ba8f"
 dependencies = [
  "quote",
  "syn 2.0.108",
@@ -371,7 +371,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-fresh-rematch#1b83c1fce51cd49dfdcb724686c65e8d9485ba8f"
 dependencies = [
  "ordered-float",
 ]
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-fresh-rematch#1b83c1fce51cd49dfdcb724686c65e8d9485ba8f"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -402,7 +402,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-fresh-rematch#1b83c1fce51cd49dfdcb724686c65e8d9485ba8f"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-fresh-rematch#1b83c1fce51cd49dfdcb724686c65e8d9485ba8f"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -457,7 +457,7 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-fresh-rematch#1b83c1fce51cd49dfdcb724686c65e8d9485ba8f"
 dependencies = [
  "rayon",
 ]
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "egglog-reports"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-fresh-rematch#1b83c1fce51cd49dfdcb724686c65e8d9485ba8f"
 dependencies = [
  "clap",
  "hashbrown 0.16.0",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-fresh-rematch#1b83c1fce51cd49dfdcb724686c65e8d9485ba8f"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { git = "https://github.com/egraphs-good/egglog.git", rev = "d330f2c632adc5d2ef7e4cfc51286ba0ed241721", default-features = false }
-egglog-ast = { git = "https://github.com/egraphs-good/egglog.git", rev = "d330f2c632adc5d2ef7e4cfc51286ba0ed241721", default-features = false }
-egglog-reports = { git = "https://github.com/egraphs-good/egglog.git", rev = "d330f2c632adc5d2ef7e4cfc51286ba0ed241721", default-features = false }
+egglog = { git = "https://github.com/saulshanabrook/egg-smol.git", branch = "codex/split-scheduler-fresh-rematch", default-features = false }
+egglog-ast = { git = "https://github.com/saulshanabrook/egg-smol.git", branch = "codex/split-scheduler-fresh-rematch", default-features = false }
+egglog-reports = { git = "https://github.com/saulshanabrook/egg-smol.git", branch = "codex/split-scheduler-fresh-rematch", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,9 @@
 //! - [Rationals support](https://egraphs-good.github.io/egglog-demo/?example=rational)
 //!   (see [`rational`] for the exposed primitives)
 //! - [Dynamic cost models with `set-cost`](https://egraphs-good.github.io/egglog-demo/?example=05-cost-model-and-extraction)
-//! - [Custom schedulers via `run-with`](https://egraphs-good.github.io/egglog-demo/?example=math-backoff)
+//! - [Custom schedulers via `run-with`](https://egraphs-good.github.io/egglog-demo/?example=math-backoff),
+//!   including `(back-off ...)` for backlog replay and `(back-off-fresh ...)`
+//!   for fresh rematching against the rebuilt e-graph each scheduler iteration
 //! - [`(get-size!)` primitive](https://github.com/egraphs-good/egglog-experimental/blob/main/tests/web-demo/node-limit.egg)
 //!   for inspecting total tuple counts or counts for specific tables
 //! - [Multi-extraction](https://github.com/egraphs-good/egglog-experimental/blob/main/tests/web-demo/multi-extract.egg)

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -4,7 +4,7 @@ use egglog::{
     CommandOutput, UserDefinedCommand,
     ast::{Command, Expr, Fact, Literal, ParseError},
     prelude::run_ruleset,
-    scheduler::{Scheduler, SchedulerId},
+    scheduler::{FreshScheduler, Scheduler, SchedulerId},
 };
 use egglog_reports::RunReport;
 use lazy_static::lazy_static;
@@ -16,6 +16,9 @@ pub trait SchedulerGen {
 }
 
 type SchedulerBuilder = Box<dyn Fn(&egglog::EGraph, &[Expr]) -> Box<dyn Scheduler> + Send + Sync>;
+/// Builder for schedulers that rematch the rebuilt e-graph every iteration.
+pub type FreshSchedulerBuilder =
+    Box<dyn Fn(&egglog::EGraph, &[Expr]) -> Box<dyn FreshScheduler> + Send + Sync>;
 
 struct ScheduleState {
     schedulers: Vec<(String, SchedulerId)>,
@@ -28,10 +31,24 @@ lazy_static! {
             Box::new(schedulers::new_back_off_scheduler) as SchedulerBuilder,
         )]))
     };
+    static ref fresh_scheduler_libs: Mutex<HashMap<String, FreshSchedulerBuilder>> = {
+        Mutex::new(HashMap::from_iter([(
+            "back-off-fresh".into(),
+            Box::new(schedulers::new_back_off_fresh_scheduler) as FreshSchedulerBuilder,
+        )]))
+    };
 }
 
 pub fn add_scheduler_builder(name: String, builder: SchedulerBuilder) {
     scheduler_libs.lock().unwrap().insert(name, builder);
+}
+
+/// Register a fresh-rematch scheduler builder for use with `let-scheduler`.
+///
+/// This parallels [`add_scheduler_builder`] for scheduler implementations whose
+/// unchosen matches should be discarded instead of kept as a backlog.
+pub fn add_fresh_scheduler_builder(name: String, builder: FreshSchedulerBuilder) {
+    fresh_scheduler_libs.lock().unwrap().insert(name, builder);
 }
 
 impl ScheduleState {
@@ -83,9 +100,26 @@ impl ScheduleState {
                             format!("Scheduler {name} already exists"),
                         )));
                     }
-                    let scheduler =
-                        (scheduler_libs.lock().unwrap().get(scheduler_name).unwrap())(egraph, args);
-                    let id = egraph.add_scheduler(scheduler);
+                    let id = if let Some(scheduler) = scheduler_libs
+                        .lock()
+                        .unwrap()
+                        .get(scheduler_name)
+                        .map(|builder| builder(egraph, args))
+                    {
+                        egraph.add_scheduler(scheduler)
+                    } else if let Some(scheduler) = fresh_scheduler_libs
+                        .lock()
+                        .unwrap()
+                        .get(scheduler_name)
+                        .map(|builder| builder(egraph, args))
+                    {
+                        egraph.add_fresh_scheduler(scheduler)
+                    } else {
+                        return Err(egglog::Error::ParseError(ParseError(
+                            span.clone(),
+                            format!("Unknown scheduler: {scheduler_name}"),
+                        )));
+                    };
                     self.schedulers.push((name.clone(), id));
                     Ok(RunReport::default())
                 }
@@ -235,16 +269,13 @@ mod schedulers {
 
     use egglog::{
         ast::{Expr, Literal},
-        scheduler::{Matches, Scheduler},
+        scheduler::{FreshScheduler, Matches, Scheduler},
     };
     use log::{debug, info};
 
     use crate::parse_tags;
 
-    pub(super) fn new_back_off_scheduler(
-        _egraph: &egglog::EGraph,
-        args: &[Expr],
-    ) -> Box<dyn Scheduler> {
+    fn parse_back_off_config(args: &[Expr]) -> (usize, usize) {
         let tags = parse_tags(args);
         let default_match_limit = tags
             .get(":match-limit")
@@ -264,15 +295,31 @@ mod schedulers {
                 *n as usize
             })
             .unwrap_or(5);
+        (default_match_limit, default_ban_length)
+    }
+
+    pub(super) fn new_back_off_scheduler(
+        _egraph: &egglog::EGraph,
+        args: &[Expr],
+    ) -> Box<dyn Scheduler> {
+        let (default_match_limit, default_ban_length) = parse_back_off_config(args);
         Box::new(BackOffScheduler {
-            default_match_limit,
-            default_ban_length,
-            stats: HashMap::new(),
+            state: BackOffState::new(default_match_limit, default_ban_length),
+        })
+    }
+
+    pub(super) fn new_back_off_fresh_scheduler(
+        _egraph: &egglog::EGraph,
+        args: &[Expr],
+    ) -> Box<dyn FreshScheduler> {
+        let (default_match_limit, default_ban_length) = parse_back_off_config(args);
+        Box::new(BackOffFreshScheduler {
+            state: BackOffState::new(default_match_limit, default_ban_length),
         })
     }
 
     #[derive(Debug, Clone)]
-    pub struct BackOffScheduler {
+    struct BackOffState {
         default_match_limit: usize,
         default_ban_length: usize,
         stats: HashMap<String, RuleStats>,
@@ -288,7 +335,15 @@ mod schedulers {
         ban_length: usize,
     }
 
-    impl BackOffScheduler {
+    impl BackOffState {
+        fn new(default_match_limit: usize, default_ban_length: usize) -> Self {
+            Self {
+                default_match_limit,
+                default_ban_length,
+                stats: HashMap::new(),
+            }
+        }
+
         fn get_stats(&mut self, rule: String) -> &mut RuleStats {
             self.stats.entry(rule).or_insert_with(|| RuleStats {
                 times_applied: 0,
@@ -299,10 +354,8 @@ mod schedulers {
                 iteration: 0,
             })
         }
-    }
 
-    impl Scheduler for BackOffScheduler {
-        fn can_stop(&mut self, rules: &[&str], _ruleset: &str) -> bool {
+        fn can_stop(&mut self, rules: &[&str]) -> bool {
             let stats = &mut self.stats;
             let n_stats = stats.len();
 
@@ -358,7 +411,7 @@ mod schedulers {
             result
         }
 
-        fn filter_matches(&mut self, rule: &str, _ruleset: &str, matches: &mut Matches) -> bool {
+        fn should_search(&mut self, rule: &str) -> bool {
             let stats = self.get_stats(rule.to_owned());
             stats.iteration += 1;
 
@@ -367,9 +420,14 @@ mod schedulers {
                     "Skipping {} ({}-{}), banned until {}...",
                     rule, stats.times_applied, stats.times_banned, stats.banned_until,
                 );
-                return false;
+                false
+            } else {
+                true
             }
+        }
 
+        fn choose_or_ban(&mut self, rule: &str, matches: &mut Matches) -> bool {
+            let stats = self.get_stats(rule.to_owned());
             let threshold = stats
                 .match_limit
                 .checked_shl(stats.times_banned as u32)
@@ -393,6 +451,40 @@ mod schedulers {
                 matches.choose_all();
                 true
             }
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct BackOffScheduler {
+        state: BackOffState,
+    }
+
+    impl Scheduler for BackOffScheduler {
+        fn can_stop(&mut self, rules: &[&str], _ruleset: &str) -> bool {
+            self.state.can_stop(rules)
+        }
+
+        fn filter_matches(&mut self, rule: &str, _ruleset: &str, matches: &mut Matches) -> bool {
+            self.state.should_search(rule) && self.state.choose_or_ban(rule, matches)
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct BackOffFreshScheduler {
+        state: BackOffState,
+    }
+
+    impl FreshScheduler for BackOffFreshScheduler {
+        fn should_search(&mut self, rule: &str, _ruleset: &str) -> bool {
+            self.state.should_search(rule)
+        }
+
+        fn can_stop(&mut self, rules: &[&str], _ruleset: &str) -> bool {
+            self.state.can_stop(rules)
+        }
+
+        fn filter_matches(&mut self, rule: &str, _ruleset: &str, matches: &mut Matches) {
+            let _ = self.state.choose_or_ban(rule, matches);
         }
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -237,3 +237,58 @@ fn test_multi_extract_with_set_cost() {
     assert!(output.contains("(Add (Num 3) (Num 3))"));
     assert!(!output.contains("Mul"));
 }
+
+fn run_backoff_copy_grow(scheduler_name: &str) -> usize {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (ruleset copy)
+        (ruleset grow)
+        (relation R (i64))
+        (relation S (i64))
+        (relation Seed ())
+        (R 0)
+        (R 1)
+        (R 2)
+        (Seed)
+        (rule ((R x)) ((S x)) :ruleset copy :name "copy")
+        (rule ((Seed)) ((R 3)) :ruleset grow :name "grow")
+        "#,
+        )
+        .unwrap();
+
+    egraph
+        .parse_and_run_program(
+            None,
+            &format!(
+                r#"
+        (run-schedule
+          (let-scheduler bo ({scheduler_name} :match-limit 2 :ban-length 2))
+          (seq
+            (run-with bo copy)
+            (run grow)
+            (run-with bo copy)))
+        "#
+            ),
+        )
+        .unwrap();
+
+    egraph.get_size("S")
+}
+
+#[test]
+fn test_backoff_fresh_rematches_rebuilt_graph_after_ban_expires() {
+    assert_eq!(
+        run_backoff_copy_grow("back-off"),
+        3,
+        "back-off should replay only the queued backlog from before grow adds R 3"
+    );
+    assert_eq!(
+        run_backoff_copy_grow("back-off-fresh"),
+        4,
+        "back-off-fresh should rematch and see the R 3 row added while copy was banned"
+    );
+}


### PR DESCRIPTION
## Context

The existing `back-off` scheduler replays a backlog of previously-seen matches. Some workloads need a scheduler that rematches the rebuilt e-graph after bans expire. This adds an experimental `back-off-fresh` scheduler on top of egglog's fresh-rematch API.

Depends on: https://github.com/egraphs-good/egglog/pull/883

## Changes

- Registers `back-off-fresh` as a fresh-rematch scheduler builder.
- Refactors shared back-off state so backlog and fresh variants share configuration and ban logic.
- Documents the distinction in the crate-level feature list.
- Adds an integration test showing `back-off-fresh` sees rows added while the rule was banned.

## Validation

- `cargo test --test integration_test backoff`
- `cargo fmt`
- `git diff --check`
