### PR TITLE
Persist scheduler bindings on EGraph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?branch=main#a2da717fd2f5eb8e8cd7c68163e5a160da05e637"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=a2da717fd2f5eb8e8cd7c68163e5a160da05e637#a2da717fd2f5eb8e8cd7c68163e5a160da05e637"
 dependencies = [
  "chrono",
  "clap",
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?branch=main#a2da717fd2f5eb8e8cd7c68163e5a160da05e637"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=a2da717fd2f5eb8e8cd7c68163e5a160da05e637#a2da717fd2f5eb8e8cd7c68163e5a160da05e637"
 dependencies = [
  "quote",
  "syn 2.0.108",
@@ -371,7 +371,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?branch=main#a2da717fd2f5eb8e8cd7c68163e5a160da05e637"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=a2da717fd2f5eb8e8cd7c68163e5a160da05e637#a2da717fd2f5eb8e8cd7c68163e5a160da05e637"
 dependencies = [
  "ordered-float",
 ]
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?branch=main#a2da717fd2f5eb8e8cd7c68163e5a160da05e637"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=a2da717fd2f5eb8e8cd7c68163e5a160da05e637#a2da717fd2f5eb8e8cd7c68163e5a160da05e637"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -402,7 +402,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?branch=main#a2da717fd2f5eb8e8cd7c68163e5a160da05e637"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=a2da717fd2f5eb8e8cd7c68163e5a160da05e637#a2da717fd2f5eb8e8cd7c68163e5a160da05e637"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?branch=main#a2da717fd2f5eb8e8cd7c68163e5a160da05e637"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=a2da717fd2f5eb8e8cd7c68163e5a160da05e637#a2da717fd2f5eb8e8cd7c68163e5a160da05e637"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -457,7 +457,7 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?branch=main#a2da717fd2f5eb8e8cd7c68163e5a160da05e637"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=a2da717fd2f5eb8e8cd7c68163e5a160da05e637#a2da717fd2f5eb8e8cd7c68163e5a160da05e637"
 dependencies = [
  "rayon",
 ]
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "egglog-reports"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?branch=main#a2da717fd2f5eb8e8cd7c68163e5a160da05e637"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=a2da717fd2f5eb8e8cd7c68163e5a160da05e637#a2da717fd2f5eb8e8cd7c68163e5a160da05e637"
 dependencies = [
  "clap",
  "hashbrown 0.16.0",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?branch=main#a2da717fd2f5eb8e8cd7c68163e5a160da05e637"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=a2da717fd2f5eb8e8cd7c68163e5a160da05e637#a2da717fd2f5eb8e8cd7c68163e5a160da05e637"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "2.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=399c70586bd4e1da9e526cbbce834f37245bbd60#399c70586bd4e1da9e526cbbce834f37245bbd60"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5#42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5"
 dependencies = [
  "chrono",
  "clap",
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "2.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=399c70586bd4e1da9e526cbbce834f37245bbd60#399c70586bd4e1da9e526cbbce834f37245bbd60"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5#42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5"
 dependencies = [
  "quote",
  "syn 2.0.108",
@@ -371,7 +371,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "2.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=399c70586bd4e1da9e526cbbce834f37245bbd60#399c70586bd4e1da9e526cbbce834f37245bbd60"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5#42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5"
 dependencies = [
  "ordered-float",
 ]
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "2.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=399c70586bd4e1da9e526cbbce834f37245bbd60#399c70586bd4e1da9e526cbbce834f37245bbd60"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5#42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -402,7 +402,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "2.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=399c70586bd4e1da9e526cbbce834f37245bbd60#399c70586bd4e1da9e526cbbce834f37245bbd60"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5#42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "2.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=399c70586bd4e1da9e526cbbce834f37245bbd60#399c70586bd4e1da9e526cbbce834f37245bbd60"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5#42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -457,7 +457,7 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "2.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=399c70586bd4e1da9e526cbbce834f37245bbd60#399c70586bd4e1da9e526cbbce834f37245bbd60"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5#42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5"
 dependencies = [
  "rayon",
 ]
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "egglog-reports"
 version = "2.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=399c70586bd4e1da9e526cbbce834f37245bbd60#399c70586bd4e1da9e526cbbce834f37245bbd60"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5#42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5"
 dependencies = [
  "clap",
  "hashbrown 0.16.0",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "2.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=399c70586bd4e1da9e526cbbce834f37245bbd60#399c70586bd4e1da9e526cbbce834f37245bbd60"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5#42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=ddf2656ec5dad02054a6149ebad59deca8c32d6d#ddf2656ec5dad02054a6149ebad59deca8c32d6d"
+source = "git+https://github.com/egraphs-good/egglog.git?branch=main#2a3db9cdd3d0ebfe8a3bce54e9b6043f5ea88032"
 dependencies = [
  "chrono",
  "clap",
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=ddf2656ec5dad02054a6149ebad59deca8c32d6d#ddf2656ec5dad02054a6149ebad59deca8c32d6d"
+source = "git+https://github.com/egraphs-good/egglog.git?branch=main#2a3db9cdd3d0ebfe8a3bce54e9b6043f5ea88032"
 dependencies = [
  "quote",
  "syn 2.0.108",
@@ -371,7 +371,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=ddf2656ec5dad02054a6149ebad59deca8c32d6d#ddf2656ec5dad02054a6149ebad59deca8c32d6d"
+source = "git+https://github.com/egraphs-good/egglog.git?branch=main#2a3db9cdd3d0ebfe8a3bce54e9b6043f5ea88032"
 dependencies = [
  "ordered-float",
 ]
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=ddf2656ec5dad02054a6149ebad59deca8c32d6d#ddf2656ec5dad02054a6149ebad59deca8c32d6d"
+source = "git+https://github.com/egraphs-good/egglog.git?branch=main#2a3db9cdd3d0ebfe8a3bce54e9b6043f5ea88032"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -402,7 +402,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=ddf2656ec5dad02054a6149ebad59deca8c32d6d#ddf2656ec5dad02054a6149ebad59deca8c32d6d"
+source = "git+https://github.com/egraphs-good/egglog.git?branch=main#2a3db9cdd3d0ebfe8a3bce54e9b6043f5ea88032"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=ddf2656ec5dad02054a6149ebad59deca8c32d6d#ddf2656ec5dad02054a6149ebad59deca8c32d6d"
+source = "git+https://github.com/egraphs-good/egglog.git?branch=main#2a3db9cdd3d0ebfe8a3bce54e9b6043f5ea88032"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -457,7 +457,7 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=ddf2656ec5dad02054a6149ebad59deca8c32d6d#ddf2656ec5dad02054a6149ebad59deca8c32d6d"
+source = "git+https://github.com/egraphs-good/egglog.git?branch=main#2a3db9cdd3d0ebfe8a3bce54e9b6043f5ea88032"
 dependencies = [
  "rayon",
 ]
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "egglog-reports"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=ddf2656ec5dad02054a6149ebad59deca8c32d6d#ddf2656ec5dad02054a6149ebad59deca8c32d6d"
+source = "git+https://github.com/egraphs-good/egglog.git?branch=main#2a3db9cdd3d0ebfe8a3bce54e9b6043f5ea88032"
 dependencies = [
  "clap",
  "hashbrown 0.16.0",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=ddf2656ec5dad02054a6149ebad59deca8c32d6d#ddf2656ec5dad02054a6149ebad59deca8c32d6d"
+source = "git+https://github.com/egraphs-good/egglog.git?branch=main#2a3db9cdd3d0ebfe8a3bce54e9b6043f5ea88032"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=399c70586bd4e1da9e526cbbce834f37245bbd60#399c70586bd4e1da9e526cbbce834f37245bbd60"
 dependencies = [
  "chrono",
  "clap",
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=399c70586bd4e1da9e526cbbce834f37245bbd60#399c70586bd4e1da9e526cbbce834f37245bbd60"
 dependencies = [
  "quote",
  "syn 2.0.108",
@@ -371,7 +371,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=399c70586bd4e1da9e526cbbce834f37245bbd60#399c70586bd4e1da9e526cbbce834f37245bbd60"
 dependencies = [
  "ordered-float",
 ]
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=399c70586bd4e1da9e526cbbce834f37245bbd60#399c70586bd4e1da9e526cbbce834f37245bbd60"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -402,7 +402,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=399c70586bd4e1da9e526cbbce834f37245bbd60#399c70586bd4e1da9e526cbbce834f37245bbd60"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=399c70586bd4e1da9e526cbbce834f37245bbd60#399c70586bd4e1da9e526cbbce834f37245bbd60"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -457,7 +457,7 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=399c70586bd4e1da9e526cbbce834f37245bbd60#399c70586bd4e1da9e526cbbce834f37245bbd60"
 dependencies = [
  "rayon",
 ]
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "egglog-reports"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=399c70586bd4e1da9e526cbbce834f37245bbd60#399c70586bd4e1da9e526cbbce834f37245bbd60"
 dependencies = [
  "clap",
  "hashbrown 0.16.0",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=399c70586bd4e1da9e526cbbce834f37245bbd60#399c70586bd4e1da9e526cbbce834f37245bbd60"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,10 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { git = "https://github.com/saulshanabrook/egg-smol.git", rev = "399c70586bd4e1da9e526cbbce834f37245bbd60", default-features = false }
-egglog-ast = { git = "https://github.com/saulshanabrook/egg-smol.git", rev = "399c70586bd4e1da9e526cbbce834f37245bbd60", default-features = false }
-egglog-reports = { git = "https://github.com/saulshanabrook/egg-smol.git", rev = "399c70586bd4e1da9e526cbbce834f37245bbd60", default-features = false }
+# Temporary pin to the egglog extension-state PR until it lands.
+egglog = { git = "https://github.com/egraphs-good/egglog.git", rev = "42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5", default-features = false }
+egglog-ast = { git = "https://github.com/egraphs-good/egglog.git", rev = "42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5", default-features = false }
+egglog-reports = { git = "https://github.com/egraphs-good/egglog.git", rev = "42bc6c43d99c6deb44e3c2cafc1a9f1436c25ff5", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { git = "https://github.com/egraphs-good/egglog.git", rev = "d330f2c632adc5d2ef7e4cfc51286ba0ed241721", default-features = false }
-egglog-ast = { git = "https://github.com/egraphs-good/egglog.git", rev = "d330f2c632adc5d2ef7e4cfc51286ba0ed241721", default-features = false }
-egglog-reports = { git = "https://github.com/egraphs-good/egglog.git", rev = "d330f2c632adc5d2ef7e4cfc51286ba0ed241721", default-features = false }
+egglog = { git = "https://github.com/saulshanabrook/egg-smol.git", rev = "399c70586bd4e1da9e526cbbce834f37245bbd60", default-features = false }
+egglog-ast = { git = "https://github.com/saulshanabrook/egg-smol.git", rev = "399c70586bd4e1da9e526cbbce834f37245bbd60", default-features = false }
+egglog-reports = { git = "https://github.com/saulshanabrook/egg-smol.git", rev = "399c70586bd4e1da9e526cbbce834f37245bbd60", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { git = "https://github.com/egraphs-good/egglog.git", branch = "main", default-features = false }
-egglog-ast = { git = "https://github.com/egraphs-good/egglog.git", branch = "main", default-features = false }
-egglog-reports = { git = "https://github.com/egraphs-good/egglog.git", branch = "main", default-features = false }
+egglog = { git = "https://github.com/egraphs-good/egglog.git", rev = "a2da717fd2f5eb8e8cd7c68163e5a160da05e637", default-features = false }
+egglog-ast = { git = "https://github.com/egraphs-good/egglog.git", rev = "a2da717fd2f5eb8e8cd7c68163e5a160da05e637", default-features = false }
+egglog-reports = { git = "https://github.com/egraphs-good/egglog.git", rev = "a2da717fd2f5eb8e8cd7c68163e5a160da05e637", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-# Temporary pin to the egglog extension-state PR until it lands.
-egglog = { git = "https://github.com/egraphs-good/egglog.git", rev = "ddf2656ec5dad02054a6149ebad59deca8c32d6d", default-features = false }
-egglog-ast = { git = "https://github.com/egraphs-good/egglog.git", rev = "ddf2656ec5dad02054a6149ebad59deca8c32d6d", default-features = false }
-egglog-reports = { git = "https://github.com/egraphs-good/egglog.git", rev = "ddf2656ec5dad02054a6149ebad59deca8c32d6d", default-features = false }
+egglog = { git = "https://github.com/egraphs-good/egglog.git", branch = "main", default-features = false }
+egglog-ast = { git = "https://github.com/egraphs-good/egglog.git", branch = "main", default-features = false }
+egglog-reports = { git = "https://github.com/egraphs-good/egglog.git", branch = "main", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,8 @@
 //! - [Rationals support](https://egraphs-good.github.io/egglog-demo/?example=rational)
 //!   (see [`rational`] for the exposed primitives)
 //! - [Dynamic cost models with `set-cost`](https://egraphs-good.github.io/egglog-demo/?example=05-cost-model-and-extraction)
-//! - [Custom schedulers via `run-with`](https://egraphs-good.github.io/egglog-demo/?example=math-backoff)
+//! - [Custom schedulers via `run-with`](https://egraphs-good.github.io/egglog-demo/?example=math-backoff),
+//!   including top-level `(let-scheduler name ...)` bindings stored on the e-graph
 //! - [`(get-size!)` primitive](https://github.com/egraphs-good/egglog-experimental/blob/main/tests/web-demo/node-limit.egg)
 //!   for inspecting total tuple counts or counts for specific tables
 //! - [Multi-extraction](https://github.com/egraphs-good/egglog-experimental/blob/main/tests/web-demo/multi-extract.egg)
@@ -63,6 +64,9 @@ pub fn new_experimental_egraph() -> EGraph {
     // scheduler support
     egraph
         .add_command("run-schedule".into(), Arc::new(RunExtendedSchedule))
+        .unwrap();
+    egraph
+        .add_command("let-scheduler".into(), Arc::new(LetSchedulerCommand))
         .unwrap();
 
     egraph

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -39,6 +39,22 @@ pub fn add_scheduler_builder(name: String, builder: SchedulerBuilder) {
     scheduler_libs.lock().unwrap().insert(name, builder);
 }
 
+fn build_scheduler(
+    egraph: &egglog::EGraph,
+    span: &Span,
+    name: &str,
+    args: &[Expr],
+) -> Result<Box<dyn Scheduler>, egglog::Error> {
+    let libs = scheduler_libs.lock().unwrap();
+    match libs.get(name) {
+        Some(builder) => Ok(builder(egraph, args)),
+        None => Err(egglog::Error::ParseError(ParseError(
+            span.clone(),
+            format!("Unknown scheduler: {name}"),
+        ))),
+    }
+}
+
 impl ScheduleState {
     fn new() -> Self {
         Self { schedulers: vec![] }
@@ -108,15 +124,17 @@ impl ScheduleState {
 
         match head.as_str() {
             "let-scheduler" => match exprs.as_slice() {
-                [Expr::Var(_, name), Expr::Call(_, scheduler_name, args)] => {
+                [
+                    Expr::Var(_, name),
+                    Expr::Call(scheduler_span, scheduler_name, args),
+                ] => {
                     if self.schedulers.iter().any(|(n, _)| n == name) {
                         return Err(egglog::Error::ParseError(ParseError(
                             span.clone(),
                             format!("Scheduler {name} already exists"),
                         )));
                     }
-                    let scheduler =
-                        (scheduler_libs.lock().unwrap().get(scheduler_name).unwrap())(egraph, args);
+                    let scheduler = build_scheduler(egraph, scheduler_span, scheduler_name, args)?;
                     let id = egraph.add_scheduler(scheduler);
                     self.schedulers.push((name.clone(), id));
                     Ok(RunReport::default())
@@ -250,7 +268,7 @@ impl UserDefinedCommand for LetSchedulerCommand {
         match args {
             [
                 Expr::Var(span, name),
-                Expr::Call(_, scheduler_name, scheduler_args),
+                Expr::Call(scheduler_span, scheduler_name, scheduler_args),
             ] => {
                 if egraph
                     .extension_state::<PermanentSchedulerState>()
@@ -263,16 +281,8 @@ impl UserDefinedCommand for LetSchedulerCommand {
                     )));
                 }
 
-                let scheduler = {
-                    let libs = scheduler_libs.lock().unwrap();
-                    let Some(builder) = libs.get(scheduler_name) else {
-                        return Err(egglog::Error::ParseError(ParseError(
-                            span.clone(),
-                            format!("Unknown scheduler: {scheduler_name}"),
-                        )));
-                    };
-                    builder(egraph, scheduler_args)
-                };
+                let scheduler =
+                    build_scheduler(egraph, scheduler_span, scheduler_name, scheduler_args)?;
                 let id = egraph.add_scheduler(scheduler);
                 egraph
                     .extension_state_or_default::<PermanentSchedulerState>()

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -3,13 +3,18 @@ use std::{collections::HashMap, sync::Mutex};
 use egglog::{
     CommandOutput, UserDefinedCommand,
     ast::{Command, Expr, Fact, Literal, ParseError},
-    prelude::run_ruleset,
+    prelude::{RustSpan, Span, run_ruleset},
     scheduler::{Scheduler, SchedulerId},
+    span,
 };
 use egglog_reports::RunReport;
 use lazy_static::lazy_static;
 
+type PermanentSchedulerState = HashMap<String, SchedulerId>;
+
 pub struct RunExtendedSchedule;
+
+pub struct LetSchedulerCommand;
 
 pub trait SchedulerGen {
     fn new_scheduler(&self, egraph: &egglog::EGraph, args: &[Expr]) -> Box<dyn Scheduler>;
@@ -37,6 +42,33 @@ pub fn add_scheduler_builder(name: String, builder: SchedulerBuilder) {
 impl ScheduleState {
     fn new() -> Self {
         Self { schedulers: vec![] }
+    }
+
+    fn lookup_scheduler(
+        &self,
+        egraph: &egglog::EGraph,
+        span: &egglog::ast::Span,
+        name: &str,
+    ) -> Result<SchedulerId, egglog::Error> {
+        if let Some(id) = self
+            .schedulers
+            .iter()
+            .rfind(|(n, _)| n == name)
+            .map(|(_, id)| *id)
+        {
+            return Ok(id);
+        }
+
+        match egraph
+            .extension_state::<PermanentSchedulerState>()
+            .and_then(|state| state.get(name).copied())
+        {
+            Some(id) => Ok(id),
+            None => Err(egglog::Error::ParseError(ParseError(
+                span.clone(),
+                format!("Unknown scheduler: {name}"),
+            ))),
+        }
     }
 
     // Current limitation: because it relies on the publicly available Rust APIs to access
@@ -94,17 +126,14 @@ impl ScheduleState {
             "run" | "run-with" => {
                 let mut scheduler = None;
                 let exprs: &[egglog::ast::Expr] = if head.as_str() == "run-with" {
-                    let Expr::Var(_, ref scheduler_name) = exprs[0] else {
+                    let Some((Expr::Var(scheduler_span, scheduler_name), rest)) =
+                        exprs.split_first()
+                    else {
                         return err();
                     };
-                    scheduler = Some(
-                        self.schedulers
-                            .iter()
-                            .rfind(|(n, _)| n == scheduler_name)
-                            .unwrap()
-                            .1,
-                    );
-                    &exprs[1..]
+                    scheduler =
+                        Some(self.lookup_scheduler(egraph, scheduler_span, scheduler_name)?);
+                    rest
                 } else {
                     &exprs[..]
                 };
@@ -209,6 +238,52 @@ impl UserDefinedCommand for RunExtendedSchedule {
             report.union(schedule.run(egraph, arg)?);
         }
         Ok(Some(CommandOutput::RunSchedule(report)))
+    }
+}
+
+impl UserDefinedCommand for LetSchedulerCommand {
+    fn update(
+        &self,
+        egraph: &mut egglog::EGraph,
+        args: &[Expr],
+    ) -> Result<Option<CommandOutput>, egglog::Error> {
+        match args {
+            [
+                Expr::Var(span, name),
+                Expr::Call(_, scheduler_name, scheduler_args),
+            ] => {
+                if egraph
+                    .extension_state::<PermanentSchedulerState>()
+                    .and_then(|state| state.get(name).copied())
+                    .is_some()
+                {
+                    return Err(egglog::Error::ParseError(ParseError(
+                        span.clone(),
+                        format!("Scheduler {name} already exists"),
+                    )));
+                }
+
+                let scheduler = {
+                    let libs = scheduler_libs.lock().unwrap();
+                    let Some(builder) = libs.get(scheduler_name) else {
+                        return Err(egglog::Error::ParseError(ParseError(
+                            span.clone(),
+                            format!("Unknown scheduler: {scheduler_name}"),
+                        )));
+                    };
+                    builder(egraph, scheduler_args)
+                };
+                let id = egraph.add_scheduler(scheduler);
+                egraph
+                    .extension_state_or_default::<PermanentSchedulerState>()
+                    .insert(name.clone(), id);
+                Ok(None)
+            }
+            invalid => Err(egglog::Error::ParseError(ParseError(
+                invalid.first().map_or_else(|| span!(), Expr::span),
+                "Invalid let-scheduler command".into(),
+            ))),
+        }
     }
 }
 

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -68,33 +68,6 @@ impl ScheduleState {
         Self { schedulers: vec![] }
     }
 
-    fn lookup_scheduler(
-        &self,
-        egraph: &egglog::EGraph,
-        span: &egglog::ast::Span,
-        name: &str,
-    ) -> Result<SchedulerId, egglog::Error> {
-        if let Some(id) = self
-            .schedulers
-            .iter()
-            .rfind(|(n, _)| n == name)
-            .map(|(_, id)| *id)
-        {
-            return Ok(id);
-        }
-
-        match egraph
-            .extension_state::<PermanentSchedulerState>()
-            .and_then(|state| state.get(name).copied())
-        {
-            Some(id) => Ok(id),
-            None => Err(egglog::Error::ParseError(ParseError(
-                span.clone(),
-                format!("Unknown scheduler: {name}"),
-            ))),
-        }
-    }
-
     // Current limitation: because it relies on the publicly available Rust APIs to access
     // the egraph, it has to split the same schedule into multiple runs. This means
     // - the same condition may be compiled and type checked multiple times
@@ -159,8 +132,23 @@ impl ScheduleState {
                     else {
                         return err();
                     };
-                    scheduler =
-                        Some(self.lookup_scheduler(egraph, scheduler_span, scheduler_name)?);
+                    scheduler = Some(
+                        self.schedulers
+                            .iter()
+                            .rfind(|(name, _)| name == scheduler_name)
+                            .map(|(_, id)| *id)
+                            .or_else(|| {
+                                egraph
+                                    .extension_state::<PermanentSchedulerState>()
+                                    .and_then(|state| state.get(scheduler_name).copied())
+                            })
+                            .ok_or_else(|| {
+                                egglog::Error::ParseError(ParseError(
+                                    scheduler_span.clone(),
+                                    format!("Unknown scheduler: {scheduler_name}"),
+                                ))
+                            })?,
+                    );
                     rest
                 } else {
                     &exprs[..]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -362,6 +362,30 @@ fn test_top_level_let_scheduler_redeclaration_returns_error() {
 }
 
 #[test]
+fn test_let_scheduler_unknown_scheduler_returns_error() {
+    let mut egraph = new_copy_egraph();
+    let err = egraph
+        .parse_and_run_program(None, "(let-scheduler bo (missing-scheduler))")
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("Unknown scheduler: missing-scheduler")
+    );
+
+    let mut egraph = new_copy_egraph();
+    let err = egraph
+        .parse_and_run_program(
+            None,
+            "(run-schedule (let-scheduler bo (missing-scheduler)))",
+        )
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("Unknown scheduler: missing-scheduler")
+    );
+}
+
+#[test]
 fn test_top_level_let_scheduler_invalidates_after_push_pop() {
     let mut egraph = new_copy_egraph();
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,7 +3,54 @@ use std::sync::Arc;
 use egglog::{
     ast::{Expr, Literal},
     prelude::{RustSpan, Span},
+    span,
 };
+
+fn eval_get_size(egraph: &mut egglog::EGraph, names: &[&str]) -> i64 {
+    let span = span!();
+    let expr = Expr::Call(
+        span.clone(),
+        "get-size!".into(),
+        names
+            .iter()
+            .map(|name| Expr::Lit(span.clone(), Literal::String((*name).into())))
+            .collect(),
+    );
+    let (_, value) = egraph.eval_expr(&expr).unwrap();
+    egraph.value_to_base::<i64>(value)
+}
+
+fn new_copy_egraph() -> egglog::EGraph {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (ruleset copy)
+        (relation R (i64))
+        (relation S (i64))
+        (R 0)
+        (rule ((R x)) ((S x)) :ruleset copy :name "copy")
+        "#,
+        )
+        .unwrap();
+    egraph
+}
+
+fn let_backoff(egraph: &mut egglog::EGraph) {
+    egraph
+        .parse_and_run_program(
+            None,
+            "(let-scheduler bo (back-off :match-limit 2 :ban-length 2))",
+        )
+        .unwrap();
+}
+
+fn run_bo_copy(egraph: &mut egglog::EGraph) {
+    egraph
+        .parse_and_run_program(None, "(run-schedule (run-with bo copy))")
+        .unwrap();
+}
 
 #[test]
 fn test_extract() {
@@ -236,4 +283,114 @@ fn test_multi_extract_with_set_cost() {
     assert!(output.contains("(Add (Num 5) (Num 5))"));
     assert!(output.contains("(Add (Num 3) (Num 3))"));
     assert!(!output.contains("Mul"));
+}
+
+#[test]
+fn test_top_level_let_scheduler_persists_on_the_egraph() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (ruleset copy)
+        (ruleset grow)
+        (relation R (i64))
+        (relation S (i64))
+        (relation Seed ())
+        (R 0)
+        (R 1)
+        (R 2)
+        (Seed)
+        (rule ((R x)) ((S x)) :ruleset copy :name "copy")
+        (rule ((Seed)) ((R 3)) :ruleset grow :name "grow")
+        "#,
+        )
+        .unwrap();
+
+    let_backoff(&mut egraph);
+
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (run-schedule
+          (seq
+            (run-with bo copy)
+            (run grow)
+            (run-with bo copy)))
+        "#,
+        )
+        .unwrap();
+
+    assert_eq!(
+        eval_get_size(&mut egraph, &["S"]),
+        3,
+        "ordinary back-off should replay the queued copy backlog and should not depend on fresh rematching"
+    );
+}
+
+#[test]
+fn test_top_level_let_scheduler_survives_egraph_clone() {
+    let mut original = new_copy_egraph();
+    let_backoff(&mut original);
+
+    let mut cloned = original.clone();
+    run_bo_copy(&mut cloned);
+    run_bo_copy(&mut original);
+
+    assert_eq!(eval_get_size(&mut cloned, &["S"]), 1);
+    assert_eq!(eval_get_size(&mut original, &["S"]), 1);
+}
+
+#[test]
+fn test_top_level_let_scheduler_redeclaration_returns_error() {
+    let mut egraph = new_copy_egraph();
+    let_backoff(&mut egraph);
+
+    let err = egraph
+        .parse_and_run_program(
+            None,
+            "(let-scheduler bo (back-off :match-limit 10 :ban-length 1))",
+        )
+        .unwrap_err();
+
+    assert!(err.to_string().contains("Scheduler bo already exists"));
+
+    run_bo_copy(&mut egraph);
+    assert_eq!(eval_get_size(&mut egraph, &["S"]), 1);
+}
+
+#[test]
+fn test_top_level_let_scheduler_invalidates_after_push_pop() {
+    let mut egraph = new_copy_egraph();
+
+    for _ in 0..2 {
+        egraph.parse_and_run_program(None, "(push)").unwrap();
+        let_backoff(&mut egraph);
+        run_bo_copy(&mut egraph);
+        assert_eq!(eval_get_size(&mut egraph, &["S"]), 1);
+        egraph.parse_and_run_program(None, "(pop)").unwrap();
+        assert_eq!(eval_get_size(&mut egraph, &["S"]), 0);
+
+        let err = egraph
+            .parse_and_run_program(None, "(run-schedule (run-with bo copy))")
+            .unwrap_err();
+        assert!(err.to_string().contains("Unknown scheduler: bo"));
+    }
+}
+
+#[test]
+fn test_top_level_let_scheduler_survives_pop_when_declared_before_push() {
+    let mut egraph = new_copy_egraph();
+    let_backoff(&mut egraph);
+    egraph.parse_and_run_program(None, "(push)").unwrap();
+    run_bo_copy(&mut egraph);
+    assert_eq!(eval_get_size(&mut egraph, &["S"]), 1);
+
+    egraph.parse_and_run_program(None, "(pop)").unwrap();
+    assert_eq!(eval_get_size(&mut egraph, &["S"]), 0);
+
+    run_bo_copy(&mut egraph);
+    assert_eq!(eval_get_size(&mut egraph, &["S"]), 1);
 }


### PR DESCRIPTION
## Summary

- Adds a top-level `let-scheduler` command that stores scheduler bindings on the e-graph.
- Lets later `run-schedule` / `run-with` forms reuse those bindings across commands.
- Keeps bindings in `EGraph` extension state so clone and `push`/`pop` follow the e-graph lifecycle.
- Rejects unknown scheduler names, unknown scheduler constructors, and redeclaration of existing top-level bindings.
- Temporarily pins egglog dependencies to `ddf2656e` from egraphs-good/egglog#884 while that core change is under review.

## Validation

- `cargo test --test integration_test let_scheduler`
- `cargo test --test integration_test scheduler_returns_error`
- `cargo test --test integration_test`
- `git diff --check`