### PR TITLE
Return errors for invalid scheduler syntax

### DIFF
--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -17,26 +17,63 @@ pub trait SchedulerGen {
 
 type SchedulerBuilder = Box<dyn Fn(&egglog::EGraph, &[Expr]) -> Box<dyn Scheduler> + Send + Sync>;
 
+type FallibleSchedulerBuilder = Box<
+    dyn Fn(
+            &egglog::EGraph,
+            &egglog::ast::Span,
+            &[Expr],
+        ) -> Result<Box<dyn Scheduler>, egglog::Error>
+        + Send
+        + Sync,
+>;
+
+enum SchedulerBuilderEntry {
+    Infallible(SchedulerBuilder),
+    Fallible(FallibleSchedulerBuilder),
+}
+
 struct ScheduleState {
     schedulers: Vec<(String, SchedulerId)>,
 }
 
 lazy_static! {
-    static ref scheduler_libs: Mutex<HashMap<String, SchedulerBuilder>> = {
+    static ref scheduler_libs: Mutex<HashMap<String, SchedulerBuilderEntry>> = {
         Mutex::new(HashMap::from_iter([(
             "back-off".into(),
-            Box::new(schedulers::new_back_off_scheduler) as SchedulerBuilder,
+            SchedulerBuilderEntry::Fallible(Box::new(schedulers::new_back_off_scheduler)),
         )]))
     };
 }
 
 pub fn add_scheduler_builder(name: String, builder: SchedulerBuilder) {
-    scheduler_libs.lock().unwrap().insert(name, builder);
+    scheduler_libs
+        .lock()
+        .unwrap()
+        .insert(name, SchedulerBuilderEntry::Infallible(builder));
 }
 
 impl ScheduleState {
     fn new() -> Self {
         Self { schedulers: vec![] }
+    }
+
+    fn build_scheduler(
+        egraph: &egglog::EGraph,
+        span: &egglog::ast::Span,
+        scheduler_name: &str,
+        args: &[Expr],
+    ) -> Result<Box<dyn Scheduler>, egglog::Error> {
+        let libs = scheduler_libs.lock().unwrap();
+        let Some(builder) = libs.get(scheduler_name) else {
+            return Err(egglog::Error::ParseError(ParseError(
+                span.clone(),
+                format!("Unknown scheduler: {scheduler_name}"),
+            )));
+        };
+        match builder {
+            SchedulerBuilderEntry::Infallible(builder) => Ok(builder(egraph, args)),
+            SchedulerBuilderEntry::Fallible(builder) => builder(egraph, span, args),
+        }
     }
 
     // Current limitation: because it relies on the publicly available Rust APIs to access
@@ -54,11 +91,10 @@ impl ScheduleState {
 
         if let Expr::Var(_, ruleset) = arg {
             let output = run_ruleset(egraph, ruleset.as_str())?;
-            assert!(output.len() == 1);
-            if let CommandOutput::RunSchedule(report) = &output[0] {
+            if let [CommandOutput::RunSchedule(report)] = output.as_slice() {
                 return Ok(report.clone());
             }
-            panic!("Expected a RunSchedule, got {:?}", output[0]);
+            return err();
         }
 
         let Expr::Call(span, head, exprs) = arg else {
@@ -83,8 +119,7 @@ impl ScheduleState {
                             format!("Scheduler {name} already exists"),
                         )));
                     }
-                    let scheduler =
-                        (scheduler_libs.lock().unwrap().get(scheduler_name).unwrap())(egraph, args);
+                    let scheduler = Self::build_scheduler(egraph, span, scheduler_name, args)?;
                     let id = egraph.add_scheduler(scheduler);
                     self.schedulers.push((name.clone(), id));
                     Ok(RunReport::default())
@@ -94,17 +129,24 @@ impl ScheduleState {
             "run" | "run-with" => {
                 let mut scheduler = None;
                 let exprs: &[egglog::ast::Expr] = if head.as_str() == "run-with" {
-                    let Expr::Var(_, ref scheduler_name) = exprs[0] else {
+                    let Some((Expr::Var(scheduler_span, scheduler_name), rest)) =
+                        exprs.split_first()
+                    else {
                         return err();
                     };
                     scheduler = Some(
                         self.schedulers
                             .iter()
                             .rfind(|(n, _)| n == scheduler_name)
-                            .unwrap()
-                            .1,
+                            .map(|(_, id)| *id)
+                            .ok_or_else(|| {
+                                egglog::Error::ParseError(ParseError(
+                                    scheduler_span.clone(),
+                                    format!("Unknown scheduler: {scheduler_name}"),
+                                ))
+                            })?,
                     );
-                    &exprs[1..]
+                    rest
                 } else {
                     &exprs[..]
                 };
@@ -113,7 +155,7 @@ impl ScheduleState {
                     None => ("", exprs),
                     Some(Expr::Var(_span, v)) if *v == ":until" => ("", exprs),
                     Some(Expr::Var(_span, ruleset)) => (ruleset.as_str(), &exprs[1..]),
-                    _ => unreachable!(),
+                    _ => return err(),
                 };
 
                 let until = match rest {
@@ -212,22 +254,39 @@ impl UserDefinedCommand for RunExtendedSchedule {
     }
 }
 
-pub(crate) fn parse_tags(args: &[Expr]) -> HashMap<String, Literal> {
+pub(crate) fn parse_tags(
+    span: &egglog::ast::Span,
+    args: &[Expr],
+) -> Result<HashMap<String, Literal>, egglog::Error> {
+    if !args.len().is_multiple_of(2) {
+        return Err(egglog::Error::ParseError(ParseError(
+            span.clone(),
+            "Scheduler tags must be key/value pairs".into(),
+        )));
+    }
     let mut tags = HashMap::new();
-    assert!(args.len().is_multiple_of(2));
     for arg in args.chunks(2) {
-        let Expr::Var(_, ref tag_name) = arg[0] else {
-            panic!("Invalid tag name: {:?}", arg[0]);
+        let Expr::Var(ref tag_span, ref tag_name) = arg[0] else {
+            return Err(egglog::Error::ParseError(ParseError(
+                arg[0].span(),
+                "Invalid scheduler tag name".into(),
+            )));
         };
         let Expr::Lit(_, lit) = &arg[1] else {
-            panic!("Invalid tag value: {:?}", arg[1]);
+            return Err(egglog::Error::ParseError(ParseError(
+                arg[1].span(),
+                format!("Invalid value for scheduler tag {tag_name}"),
+            )));
         };
-        if tags.contains_key(&tag_name.to_string()) {
-            panic!("Tag name already exists: {:?}", tag_name);
+        if tags.contains_key(tag_name) {
+            return Err(egglog::Error::ParseError(ParseError(
+                tag_span.clone(),
+                format!("Scheduler tag {tag_name} already exists"),
+            )));
         }
         tags.insert(tag_name.to_string(), lit.clone());
     }
-    tags
+    Ok(tags)
 }
 
 mod schedulers {
@@ -241,34 +300,55 @@ mod schedulers {
 
     use crate::parse_tags;
 
-    pub(super) fn new_back_off_scheduler(
-        _egraph: &egglog::EGraph,
+    fn parse_back_off_config(
+        span: &egglog::ast::Span,
         args: &[Expr],
-    ) -> Box<dyn Scheduler> {
-        let tags = parse_tags(args);
+    ) -> Result<(usize, usize), egglog::Error> {
+        let tags = parse_tags(span, args)?;
         let default_match_limit = tags
             .get(":match-limit")
-            .map(|lit| {
-                let Literal::Int(n) = lit else {
-                    panic!("Invalid match limit: {:?}", lit);
-                };
-                *n as usize
+            .map(|lit| match lit {
+                Literal::Int(n) if *n >= 0 => Ok(*n as usize),
+                Literal::Int(_) => Err(egglog::Error::ParseError(egglog::ast::ParseError(
+                    span.clone(),
+                    "Scheduler :match-limit must be non-negative".into(),
+                ))),
+                _ => Err(egglog::Error::ParseError(egglog::ast::ParseError(
+                    span.clone(),
+                    "Scheduler :match-limit must be an integer".into(),
+                ))),
             })
+            .transpose()?
             .unwrap_or(1000);
         let default_ban_length = tags
             .get(":ban-length")
-            .map(|lit| {
-                let Literal::Int(n) = lit else {
-                    panic!("Invalid ban length: {:?}", lit);
-                };
-                *n as usize
+            .map(|lit| match lit {
+                Literal::Int(n) if *n >= 0 => Ok(*n as usize),
+                Literal::Int(_) => Err(egglog::Error::ParseError(egglog::ast::ParseError(
+                    span.clone(),
+                    "Scheduler :ban-length must be non-negative".into(),
+                ))),
+                _ => Err(egglog::Error::ParseError(egglog::ast::ParseError(
+                    span.clone(),
+                    "Scheduler :ban-length must be an integer".into(),
+                ))),
             })
+            .transpose()?
             .unwrap_or(5);
-        Box::new(BackOffScheduler {
+        Ok((default_match_limit, default_ban_length))
+    }
+
+    pub(super) fn new_back_off_scheduler(
+        _egraph: &egglog::EGraph,
+        span: &egglog::ast::Span,
+        args: &[Expr],
+    ) -> Result<Box<dyn Scheduler>, egglog::Error> {
+        let (default_match_limit, default_ban_length) = parse_back_off_config(span, args)?;
+        Ok(Box::new(BackOffScheduler {
             default_match_limit,
             default_ban_length,
             stats: HashMap::new(),
-        })
+        }))
     }
 
     #[derive(Debug, Clone)]

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -15,9 +15,7 @@ pub trait SchedulerGen {
     fn new_scheduler(&self, egraph: &egglog::EGraph, args: &[Expr]) -> Box<dyn Scheduler>;
 }
 
-type SchedulerBuilder = Box<dyn Fn(&egglog::EGraph, &[Expr]) -> Box<dyn Scheduler> + Send + Sync>;
-
-type FallibleSchedulerBuilder = Box<
+type SchedulerBuilder = Box<
     dyn Fn(
             &egglog::EGraph,
             &egglog::ast::Span,
@@ -27,53 +25,26 @@ type FallibleSchedulerBuilder = Box<
         + Sync,
 >;
 
-enum SchedulerBuilderEntry {
-    Infallible(SchedulerBuilder),
-    Fallible(FallibleSchedulerBuilder),
-}
-
 struct ScheduleState {
     schedulers: Vec<(String, SchedulerId)>,
 }
 
 lazy_static! {
-    static ref scheduler_libs: Mutex<HashMap<String, SchedulerBuilderEntry>> = {
+    static ref scheduler_libs: Mutex<HashMap<String, SchedulerBuilder>> = {
         Mutex::new(HashMap::from_iter([(
             "back-off".into(),
-            SchedulerBuilderEntry::Fallible(Box::new(schedulers::new_back_off_scheduler)),
+            Box::new(schedulers::new_back_off_scheduler) as SchedulerBuilder,
         )]))
     };
 }
 
 pub fn add_scheduler_builder(name: String, builder: SchedulerBuilder) {
-    scheduler_libs
-        .lock()
-        .unwrap()
-        .insert(name, SchedulerBuilderEntry::Infallible(builder));
+    scheduler_libs.lock().unwrap().insert(name, builder);
 }
 
 impl ScheduleState {
     fn new() -> Self {
         Self { schedulers: vec![] }
-    }
-
-    fn build_scheduler(
-        egraph: &egglog::EGraph,
-        span: &egglog::ast::Span,
-        scheduler_name: &str,
-        args: &[Expr],
-    ) -> Result<Box<dyn Scheduler>, egglog::Error> {
-        let libs = scheduler_libs.lock().unwrap();
-        let Some(builder) = libs.get(scheduler_name) else {
-            return Err(egglog::Error::ParseError(ParseError(
-                span.clone(),
-                format!("Unknown scheduler: {scheduler_name}"),
-            )));
-        };
-        match builder {
-            SchedulerBuilderEntry::Infallible(builder) => Ok(builder(egraph, args)),
-            SchedulerBuilderEntry::Fallible(builder) => builder(egraph, span, args),
-        }
     }
 
     // Current limitation: because it relies on the publicly available Rust APIs to access
@@ -119,7 +90,16 @@ impl ScheduleState {
                             format!("Scheduler {name} already exists"),
                         )));
                     }
-                    let scheduler = Self::build_scheduler(egraph, span, scheduler_name, args)?;
+                    let scheduler = {
+                        let libs = scheduler_libs.lock().unwrap();
+                        let Some(builder) = libs.get(scheduler_name) else {
+                            return Err(egglog::Error::ParseError(ParseError(
+                                span.clone(),
+                                format!("Unknown scheduler: {scheduler_name}"),
+                            )));
+                        };
+                        builder(egraph, span, args)?
+                    };
                     let id = egraph.add_scheduler(scheduler);
                     self.schedulers.push((name.clone(), id));
                     Ok(RunReport::default())
@@ -301,10 +281,11 @@ mod schedulers {
 
     use crate::parse_tags;
 
-    fn parse_back_off_config(
+    pub(super) fn new_back_off_scheduler(
+        _egraph: &egglog::EGraph,
         span: &egglog::ast::Span,
         args: &[Expr],
-    ) -> Result<(usize, usize), egglog::Error> {
+    ) -> Result<Box<dyn Scheduler>, egglog::Error> {
         let tags = parse_tags(span, args)?;
         let default_match_limit = tags
             .get(":match-limit")
@@ -336,15 +317,6 @@ mod schedulers {
             })
             .transpose()?
             .unwrap_or(5);
-        Ok((default_match_limit, default_ban_length))
-    }
-
-    pub(super) fn new_back_off_scheduler(
-        _egraph: &egglog::EGraph,
-        span: &egglog::ast::Span,
-        args: &[Expr],
-    ) -> Result<Box<dyn Scheduler>, egglog::Error> {
-        let (default_match_limit, default_ban_length) = parse_back_off_config(span, args)?;
         Ok(Box::new(BackOffScheduler {
             default_match_limit,
             default_ban_length,

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -65,7 +65,10 @@ impl ScheduleState {
             if let [CommandOutput::RunSchedule(report)] = output.as_slice() {
                 return Ok(report.clone());
             }
-            return err();
+            return Err(egglog::Error::ParseError(ParseError(
+                arg.span(),
+                format!("Expected ruleset {ruleset} to produce one RunSchedule output"),
+            )));
         }
 
         let Expr::Call(span, head, exprs) = arg else {
@@ -135,7 +138,12 @@ impl ScheduleState {
                     None => ("", exprs),
                     Some(Expr::Var(_span, v)) if *v == ":until" => ("", exprs),
                     Some(Expr::Var(_span, ruleset)) => (ruleset.as_str(), &exprs[1..]),
-                    _ => return err(),
+                    Some(expr) => {
+                        return Err(egglog::Error::ParseError(ParseError(
+                            expr.span(),
+                            "Expected ruleset name or :until clause in run schedule".into(),
+                        )));
+                    }
                 };
 
                 let until = match rest {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -237,3 +237,107 @@ fn test_multi_extract_with_set_cost() {
     assert!(output.contains("(Add (Num 3) (Num 3))"));
     assert!(!output.contains("Mul"));
 }
+
+#[test]
+fn test_invalid_run_schedule_returns_error_instead_of_panicking() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    let err = egraph
+        .parse_and_run_program(None, "(run-schedule (run 1))")
+        .unwrap_err();
+
+    assert!(err.to_string().contains("Invalid schedule"));
+}
+
+#[test]
+fn test_unknown_scheduler_returns_error_instead_of_panicking() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    let err = egraph
+        .parse_and_run_program(None, "(run-schedule (let-scheduler bo (not-a-scheduler)))")
+        .unwrap_err();
+
+    assert!(err.to_string().contains("Unknown scheduler"));
+}
+
+#[test]
+fn test_unknown_scheduler_binding_returns_error_instead_of_panicking() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    let err = egraph
+        .parse_and_run_program(None, "(run-schedule (run-with bo))")
+        .unwrap_err();
+
+    assert!(err.to_string().contains("Unknown scheduler"));
+}
+
+#[test]
+fn test_invalid_scheduler_tags_return_error_instead_of_panicking() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    let err = egraph
+        .parse_and_run_program(
+            None,
+            r#"(run-schedule (let-scheduler bo (back-off "x" 1)))"#,
+        )
+        .unwrap_err();
+
+    assert!(err.to_string().contains("Invalid scheduler tag name"));
+}
+
+#[test]
+fn test_odd_scheduler_tags_return_error_instead_of_panicking() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    let err = egraph
+        .parse_and_run_program(
+            None,
+            "(run-schedule (let-scheduler bo (back-off :match-limit)))",
+        )
+        .unwrap_err();
+
+    assert!(err.to_string().contains("key/value pairs"));
+}
+
+#[test]
+fn test_duplicate_scheduler_tags_return_error_instead_of_panicking() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    let err = egraph
+        .parse_and_run_program(
+            None,
+            "(run-schedule (let-scheduler bo (back-off :match-limit 1 :match-limit 2)))",
+        )
+        .unwrap_err();
+
+    assert!(err.to_string().contains("already exists"));
+}
+
+#[test]
+fn test_invalid_scheduler_config_returns_error_instead_of_panicking() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    let err = egraph
+        .parse_and_run_program(
+            None,
+            r#"(run-schedule (let-scheduler bo (back-off :match-limit "x")))"#,
+        )
+        .unwrap_err();
+
+    assert!(err.to_string().contains(":match-limit"));
+}
+
+#[test]
+fn test_negative_scheduler_config_returns_error_instead_of_panicking() {
+    for tag in [":match-limit", ":ban-length"] {
+        let mut egraph = egglog_experimental::new_experimental_egraph();
+        let err = egraph
+            .parse_and_run_program(
+                None,
+                &format!("(run-schedule (let-scheduler bo (back-off {tag} -1)))"),
+            )
+            .unwrap_err();
+
+        assert!(err.to_string().contains("non-negative"));
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -247,7 +247,10 @@ fn test_invalid_run_schedule_returns_error_instead_of_panicking() {
         .parse_and_run_program(None, "(run-schedule (run 1))")
         .unwrap_err();
 
-    assert!(err.to_string().contains("Invalid schedule"));
+    assert!(
+        err.to_string()
+            .contains("Expected ruleset name or :until clause")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Context

Several invalid scheduler forms used to panic via assertions, unchecked lookups, or `unreachable!`. This turns those cases into normal parse/configuration errors.

## Changes

- Adds fallible scheduler builders for scheduler implementations that validate arguments.
- Returns errors for unknown scheduler names and unknown scheduler bindings.
- Validates scheduler tags as key/value pairs with atom keys and literal values.
- Rejects duplicate scheduler tags and negative/non-integer back-off configuration.
- Avoids panics for malformed schedule syntax.

## Validation

- `cargo test scheduler --test integration_test`
- `cargo test schedule --test integration_test`
- `cargo fmt`
- `git diff --check`
