### PR TITLE
Harden extract command errors

### DIFF
--- a/src/multi_extract.rs
+++ b/src/multi_extract.rs
@@ -4,12 +4,14 @@
 //! The syntax for multi-extraction is `(multi-extract n t1 ... tm)`,
 //! where n must be a positive i64.
 //! This command will extract n lowest-cost variants of each of the m terms.
-//! `(multi-extract 1 t)` is equivalent to `(extract t)`.
+//! `(multi-extract 1 t)` is equivalent to `(extract t)`. Unlike
+//! `(extract t 0)`, `(multi-extract 0 t)` is rejected.
 
 use egglog::{
     CommandOutput, EGraph, Error, TermDag, TermId, TypeError, UserDefinedCommand,
-    ast::Expr,
+    ast::{Expr, ParseError},
     extract::{Cost, CostModel, Extractor},
+    prelude::{RustSpan, Span},
 };
 use log::log_enabled;
 use std::{fmt::Debug, marker::PhantomData};
@@ -57,7 +59,19 @@ impl<
 > UserDefinedCommand for MultiExtract<C, CM>
 {
     fn update(&self, egraph: &mut EGraph, args: &[Expr]) -> Result<Option<CommandOutput>, Error> {
-        assert!(args.len() >= 2);
+        if args.len() < 2 {
+            let span = args.first().map(Expr::span).unwrap_or_else(|| {
+                Span::Rust(std::sync::Arc::new(RustSpan {
+                    file: "egglog-experimental",
+                    line: 0,
+                    column: 0,
+                }))
+            });
+            return Err(Error::ParseError(ParseError(
+                span,
+                "multi-extract expects at least a variant count and one expression".into(),
+            )));
+        }
 
         let (variants_sort, variants_value) = egraph.eval_expr(&args[0])?;
         if variants_sort.name() != "i64" {
@@ -70,7 +84,16 @@ impl<
 
         let n: i64 = egraph.value_to_base(variants_value);
         if n < 0 {
-            panic!("Cannot extract negative number of variants");
+            return Err(Error::ParseError(ParseError(
+                args[0].span(),
+                "Cannot extract negative number of variants".into(),
+            )));
+        }
+        if n == 0 {
+            return Err(Error::ParseError(ParseError(
+                args[0].span(),
+                "multi-extract requires a positive number of variants".into(),
+            )));
         }
 
         let (sorts, values): (Vec<_>, Vec<_>) = args[1..]

--- a/src/multi_extract.rs
+++ b/src/multi_extract.rs
@@ -11,7 +11,7 @@ use egglog::{
     CommandOutput, EGraph, Error, TermDag, TermId, TypeError, UserDefinedCommand,
     ast::{Expr, ParseError},
     extract::{Cost, CostModel, Extractor},
-    prelude::{RustSpan, Span},
+    prelude::{RustSpan, Span, span},
 };
 use log::log_enabled;
 use std::{fmt::Debug, marker::PhantomData};
@@ -60,13 +60,7 @@ impl<
 {
     fn update(&self, egraph: &mut EGraph, args: &[Expr]) -> Result<Option<CommandOutput>, Error> {
         if args.len() < 2 {
-            let span = args.first().map(Expr::span).unwrap_or_else(|| {
-                Span::Rust(std::sync::Arc::new(RustSpan {
-                    file: "egglog-experimental",
-                    line: 0,
-                    column: 0,
-                }))
-            });
+            let span = args.first().map(Expr::span).unwrap_or_else(|| span!());
             return Err(Error::ParseError(ParseError(
                 span,
                 "multi-extract expects at least a variant count and one expression".into(),

--- a/src/set_cost.rs
+++ b/src/set_cost.rs
@@ -1,4 +1,4 @@
-use egglog_ast::span::Span;
+use egglog_ast::span::{RustSpan, Span};
 use std::sync::Arc;
 
 use egglog::{
@@ -222,7 +222,25 @@ impl UserDefinedCommand for CustomExtract {
         egraph: &mut EGraph,
         args: &[Expr],
     ) -> Result<Option<CommandOutput>, egglog::Error> {
-        assert!(args.len() <= 2);
+        match args {
+            [] => {
+                return Err(Error::ParseError(ParseError(
+                    Span::Rust(Arc::new(RustSpan {
+                        file: "egglog-experimental",
+                        line: 0,
+                        column: 0,
+                    })),
+                    "extract expects an expression and optional variant count".into(),
+                )));
+            }
+            [_, _, _, ..] => {
+                return Err(Error::ParseError(ParseError(
+                    args[2].span(),
+                    "extract expects at most two arguments".into(),
+                )));
+            }
+            _ => {}
+        }
         let (sort, value) = egraph.eval_expr(&args[0])?;
         let n = args.get(1).map(|arg| egraph.eval_expr(arg)).transpose()?;
         let n = if let Some(nv) = n {
@@ -240,6 +258,13 @@ impl UserDefinedCommand for CustomExtract {
             0
         };
 
+        if n < 0 {
+            return Err(Error::ParseError(ParseError(
+                args[1].span(),
+                "Cannot extract negative number of variants".into(),
+            )));
+        }
+
         let mut termdag = TermDag::default();
 
         let extractor = Extractor::compute_costs_from_rootsorts(
@@ -247,6 +272,8 @@ impl UserDefinedCommand for CustomExtract {
             egraph,
             DynamicCostModel,
         );
+        // Preserve egglog's existing convention: omitted or zero variant count
+        // means best extraction. Positive counts request multiple variants.
         if n == 0 {
             if let Some((cost, term)) = extractor.extract_best(egraph, &mut termdag, value) {
                 if log_enabled!(log::Level::Info) {
@@ -260,9 +287,6 @@ impl UserDefinedCommand for CustomExtract {
                 ))
             }
         } else {
-            if n < 0 {
-                panic!("Cannot extract negative number of variants");
-            }
             let terms: Vec<TermId> = extractor
                 .extract_variants(egraph, &mut termdag, value, n as usize)
                 .iter()

--- a/src/set_cost.rs
+++ b/src/set_cost.rs
@@ -5,6 +5,7 @@ use egglog::{
     CommandOutput, EGraph, Error, TermDag, TermId, TypeError, UserDefinedCommand,
     ast::*,
     extract::{CostModel, DefaultCost, Extractor, TreeAdditiveCostModel},
+    span,
     util::FreshGen,
 };
 use log::log_enabled;
@@ -225,11 +226,7 @@ impl UserDefinedCommand for CustomExtract {
         match args {
             [] => {
                 return Err(Error::ParseError(ParseError(
-                    Span::Rust(Arc::new(RustSpan {
-                        file: "egglog-experimental",
-                        line: 0,
-                        column: 0,
-                    })),
+                    span!(),
                     "extract expects an expression and optional variant count".into(),
                 )));
             }
@@ -272,8 +269,7 @@ impl UserDefinedCommand for CustomExtract {
             egraph,
             DynamicCostModel,
         );
-        // Preserve egglog's existing convention: omitted or zero variant count
-        // means best extraction. Positive counts request multiple variants.
+        // Omitted or zero variant count means best extraction.
         if n == 0 {
             if let Some((cost, term)) = extractor.extract_best(egraph, &mut termdag, value) {
                 if log_enabled!(log::Level::Info) {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -237,3 +237,109 @@ fn test_multi_extract_with_set_cost() {
     assert!(output.contains("(Add (Num 3) (Num 3))"));
     assert!(!output.contains("Mul"));
 }
+
+#[test]
+fn test_extract_missing_expression_returns_error_instead_of_panicking() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    let err = egraph.parse_and_run_program(None, "(extract)").unwrap_err();
+
+    assert!(
+        err.to_string()
+            .contains("extract expects an expression and optional variant count")
+    );
+}
+
+#[test]
+fn test_extract_extra_arguments_return_error_instead_of_panicking() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    let err = egraph
+        .parse_and_run_program(None, "(extract 0 1 2)")
+        .unwrap_err();
+
+    assert!(
+        err.to_string()
+            .contains("extract expects at most two arguments")
+    );
+}
+
+#[test]
+fn test_extract_negative_variants_returns_error_instead_of_panicking() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    egraph
+        .parse_and_run_program(None, "(datatype E (Num i64))")
+        .unwrap();
+
+    let err = egraph
+        .parse_and_run_program(None, "(extract (Num 1) -1)")
+        .unwrap_err();
+
+    assert!(err.to_string().contains("negative number of variants"));
+}
+
+#[test]
+fn test_extract_zero_variants_preserves_best_extract_behavior() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    let result = egraph
+        .parse_and_run_program(
+            None,
+            "
+        (with-dynamic-cost
+            (datatype E (Add E E :cost 10) (Num i64 :cost 1))
+        )
+        (union (Num 2) (Add (Num 1) (Num 1)))
+        (extract (Num 2) 0)",
+        )
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].to_string(), "(Num 2)\n");
+}
+
+#[test]
+fn test_multi_extract_bad_arity_returns_error_instead_of_panicking() {
+    for program in ["(multi-extract)", "(multi-extract 1)"] {
+        let mut egraph = egglog_experimental::new_experimental_egraph();
+
+        let err = egraph.parse_and_run_program(None, program).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("multi-extract expects at least a variant count and one expression"),
+            "unexpected error for {program}: {err}"
+        );
+    }
+}
+
+#[test]
+fn test_multi_extract_negative_variants_returns_error_instead_of_panicking() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    egraph
+        .parse_and_run_program(None, "(datatype E (Num i64))")
+        .unwrap();
+
+    let err = egraph
+        .parse_and_run_program(None, "(multi-extract -1 (Num 1))")
+        .unwrap_err();
+
+    assert!(err.to_string().contains("negative number of variants"));
+}
+
+#[test]
+fn test_multi_extract_zero_variants_returns_error_instead_of_extracting() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    egraph
+        .parse_and_run_program(None, "(datatype E (Num i64))")
+        .unwrap();
+
+    let err = egraph
+        .parse_and_run_program(None, "(multi-extract 0 (Num 1))")
+        .unwrap_err();
+
+    assert!(err.to_string().contains("positive number of variants"));
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -312,6 +312,9 @@ fn test_multi_extract_bad_arity_returns_error_instead_of_panicking() {
                 .contains("multi-extract expects at least a variant count and one expression"),
             "unexpected error for {program}: {err}"
         );
+    }
+}
+
 fn add_copy_backoff_program(egraph: &mut egglog::EGraph) {
     egraph
         .parse_and_run_program(
@@ -365,6 +368,9 @@ fn test_multi_extract_zero_variants_returns_error_instead_of_extracting() {
         .unwrap_err();
 
     assert!(err.to_string().contains("positive number of variants"));
+}
+
+#[test]
 fn test_backoff_run_schedule_should_not_report_progress_without_egraph_updates() {
     let mut egraph = egglog_experimental::new_experimental_egraph();
     add_copy_backoff_program(&mut egraph);


### PR DESCRIPTION
## Context

Invalid `extract` and `multi-extract` calls could panic. This hardens those command paths so user-facing errors are returned instead.

## Changes

- Returns parse errors for missing or extra `extract` arguments.
- Returns parse errors for negative extraction variant counts.
- Preserves existing `(extract term 0)` best-extract behavior.
- Returns parse errors for invalid `multi-extract` arity, negative counts, and zero counts.
- Documents that `multi-extract 0` is rejected while `extract term 0` remains best extraction.

## Validation

- `cargo test extract --test integration_test`
- `cargo fmt`
- `git diff --check`
