### PR TITLE
Update to typed egglog primitive API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=602a6bd#602a6bdc15f1eca596fba1a99d098bd4cd264456"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
 dependencies = [
  "chrono",
  "clap",
@@ -343,6 +343,7 @@ dependencies = [
  "egglog-numeric-id",
  "egglog-reports",
  "egraph-serialize",
+ "enum-map",
  "env_logger",
  "hashbrown 0.16.0",
  "im-rc",
@@ -361,7 +362,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=602a6bd#602a6bdc15f1eca596fba1a99d098bd4cd264456"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
 dependencies = [
  "quote",
  "syn 2.0.108",
@@ -370,7 +371,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=602a6bd#602a6bdc15f1eca596fba1a99d098bd4cd264456"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
 dependencies = [
  "ordered-float",
 ]
@@ -378,7 +379,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=602a6bd#602a6bdc15f1eca596fba1a99d098bd4cd264456"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -401,7 +402,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=602a6bd#602a6bdc15f1eca596fba1a99d098bd4cd264456"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -413,7 +414,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=602a6bd#602a6bdc15f1eca596fba1a99d098bd4cd264456"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -456,7 +457,7 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=602a6bd#602a6bdc15f1eca596fba1a99d098bd4cd264456"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
 dependencies = [
  "rayon",
 ]
@@ -464,7 +465,7 @@ dependencies = [
 [[package]]
 name = "egglog-reports"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=602a6bd#602a6bdc15f1eca596fba1a99d098bd4cd264456"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
 dependencies = [
  "clap",
  "hashbrown 0.16.0",
@@ -478,7 +479,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=602a6bd#602a6bdc15f1eca596fba1a99d098bd4cd264456"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=d330f2c632adc5d2ef7e4cfc51286ba0ed241721#d330f2c632adc5d2ef7e4cfc51286ba0ed241721"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",
@@ -504,6 +505,26 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
 
 [[package]]
 name = "env_filter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { git = "https://github.com/egraphs-good/egglog.git", default-features = false, rev = "602a6bd" }
-egglog-ast = { git = "https://github.com/egraphs-good/egglog.git", default-features = false, rev = "602a6bd" }
-egglog-reports = { git = "https://github.com/egraphs-good/egglog.git", default-features = false, rev = "602a6bd" }
+egglog = { git = "https://github.com/egraphs-good/egglog.git", rev = "d330f2c632adc5d2ef7e4cfc51286ba0ed241721", default-features = false }
+egglog-ast = { git = "https://github.com/egraphs-good/egglog.git", rev = "d330f2c632adc5d2ef7e4cfc51286ba0ed241721", default-features = false }
+egglog-reports = { git = "https://github.com/egraphs-good/egglog.git", rev = "d330f2c632adc5d2ef7e4cfc51286ba0ed241721", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! - [Dynamic cost models with `set-cost`](https://egraphs-good.github.io/egglog-demo/?example=05-cost-model-and-extraction)
 //! - [Custom schedulers via `run-with`](https://egraphs-good.github.io/egglog-demo/?example=math-backoff)
 //! - [`(get-size!)` primitive](https://github.com/egraphs-good/egglog-experimental/blob/main/tests/web-demo/node-limit.egg)
-//!   for inspecting total tuple counts, optionally restricted to specific tables
+//!   for inspecting total tuple counts or counts for specific tables
 //! - [Multi-extraction](https://github.com/egraphs-good/egglog-experimental/blob/main/tests/web-demo/multi-extract.egg)
 //!
 //! Each bullet links to a runnable demo so you can explore the feature quickly.
@@ -53,7 +53,7 @@ pub fn new_experimental_egraph() -> EGraph {
 
     // Support for set cost
     add_set_cost(&mut egraph);
-    egraph.add_primitive(GetSizePrimitive);
+    egraph.add_read_primitive(GetSizePrimitive, None);
 
     // unstable-fresh! macro
     egraph

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -2,8 +2,8 @@ use std::{collections::HashMap, sync::Mutex};
 
 use egglog::{
     CommandOutput, UserDefinedCommand,
-    ast::{Expr, Fact, Facts, Literal, ParseError},
-    prelude::{query, run_ruleset},
+    ast::{Command, Expr, Fact, Literal, ParseError},
+    prelude::run_ruleset,
     scheduler::{Scheduler, SchedulerId},
 };
 use egglog_reports::RunReport;
@@ -123,9 +123,11 @@ impl ScheduleState {
                 };
 
                 if let Some(until) = until {
-                    // Parse the facts from the `until` expression
-                    let res = query(egraph, &[], Facts(vec![Fact::Fact(until)]))?;
-                    if res.any_matches() {
+                    let span = until.span();
+                    if egraph
+                        .run_program(vec![Command::Check(span, vec![Fact::Fact(until)])])
+                        .is_ok()
+                    {
                         return Ok(RunReport::default());
                     }
                 }

--- a/src/size.rs
+++ b/src/size.rs
@@ -1,7 +1,7 @@
-use std::{collections::HashSet, convert::TryFrom};
+use std::convert::TryFrom;
 
 use egglog::{
-    ExecutionState, Primitive, Value,
+    Core, Primitive, Read, ReadPrim, ReadState, Value,
     constraint::{AllEqualTypeConstraint, TypeConstraint},
     prelude::BaseSort,
     prelude::{I64Sort, Span, StringSort},
@@ -23,34 +23,25 @@ impl Primitive for GetSizePrimitive {
             .with_all_arguments_sort(StringSort.to_arcsort())
             .into_box()
     }
+}
 
-    fn apply(&self, exec_state: &mut ExecutionState, args: &[Value]) -> Option<Value> {
-        let filters: Option<HashSet<String>> = if args.is_empty() {
-            None
-        } else {
-            Some(
-                args.iter()
-                    .map(|value| exec_state.base_values().unwrap::<S>(*value).0)
-                    .collect::<HashSet<_>>(),
-            )
+impl ReadPrim for GetSizePrimitive {
+    fn apply<'a, 'db>(&self, state: ReadState<'a, 'db>, args: &[Value]) -> Option<Value> {
+        let size: usize = match args {
+            [] => state
+                .table_sizes()
+                .into_iter()
+                .filter_map(|(name, size)| {
+                    (!name.starts_with(INTERNAL_SYMBOL_PREFIX)).then_some(size)
+                })
+                .sum(),
+            tables => tables
+                .iter()
+                .map(|value| state.base_values().unwrap::<S>(*value).0)
+                .filter_map(|name| state.table_size(&name))
+                .sum(),
         };
-
-        let total_size: usize = exec_state
-            .table_ids()
-            .filter_map(|table_id| {
-                let name = exec_state.table_name(table_id)?;
-                if name.starts_with(INTERNAL_SYMBOL_PREFIX) {
-                    return None;
-                }
-                if let Some(filter) = &filters
-                    && !filter.contains(name)
-                {
-                    return None;
-                }
-                Some(exec_state.get_table(table_id).len())
-            })
-            .sum();
-        let total_size = i64::try_from(total_size).ok()?;
-        Some(exec_state.base_values().get::<i64>(total_size))
+        let size = i64::try_from(size).ok()?;
+        Some(state.base_values().get::<i64>(size))
     }
 }

--- a/src/sugar/for.rs
+++ b/src/sugar/for.rs
@@ -42,6 +42,7 @@ impl Macro<Vec<Command>> for For {
             body: query,
             name: rulename,
             ruleset: ruleset.clone(),
+            naive: false,
         };
 
         Ok(vec![


### PR DESCRIPTION
## Summary

Updates `egglog`, `egglog-ast`, and `egglog-reports` to the merged egraphs-good/egglog#892 commit using an explicit Cargo `rev` pin.

Cargo currently resolves those dependencies to egglog commit `d330f2c632adc5d2ef7e4cfc51286ba0ed241721`.

Adapts experimental to the typed primitive API by registering `(get-size!)` as a `ReadPrim`, adding the new `Rule::naive` field in the `for` macro, and evaluating scheduler `:until` conditions through the normal check command path.

`get-size!` preserves the existing behavior while moving onto the new read APIs:

- `(get-size!)` uses `Read::table_sizes()` to aggregate all non-internal table sizes.
- `(get-size! "Table")` uses the cheap named-table path through `Read::table_size(name)`.
- `(get-size! "A" "B" ...)` iterates the supplied names, calls `Read::table_size(name)` for each explicitly requested table, and sums the results.

The explicit-name forms intentionally do not filter internal-prefixed names; explicit names are treated as exact table requests.

## Validation

- `cargo check`
- `cargo test test_get_size_primitive`
- `cargo test --test files get_size`
- `cargo test --test files node_limit`
