### PR TITLE
Enabling eqsat-extraction loop (i.e., pulsing)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "2.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-can-stop-report#ebba7bb902bdc1b0f377b6bb22c06ac305912674"
+source = "git+https://github.com/egraphs-good/egglog?rev=15eec00#15eec00c5a8eed0d88b8277be3aa5c0c7b4ed3f7"
 dependencies = [
  "chrono",
  "clap",
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "2.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-can-stop-report#ebba7bb902bdc1b0f377b6bb22c06ac305912674"
+source = "git+https://github.com/egraphs-good/egglog?rev=15eec00#15eec00c5a8eed0d88b8277be3aa5c0c7b4ed3f7"
 dependencies = [
  "quote",
  "syn 2.0.108",
@@ -371,7 +371,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "2.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-can-stop-report#ebba7bb902bdc1b0f377b6bb22c06ac305912674"
+source = "git+https://github.com/egraphs-good/egglog?rev=15eec00#15eec00c5a8eed0d88b8277be3aa5c0c7b4ed3f7"
 dependencies = [
  "ordered-float",
 ]
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "2.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-can-stop-report#ebba7bb902bdc1b0f377b6bb22c06ac305912674"
+source = "git+https://github.com/egraphs-good/egglog?rev=15eec00#15eec00c5a8eed0d88b8277be3aa5c0c7b4ed3f7"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -402,7 +402,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "2.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-can-stop-report#ebba7bb902bdc1b0f377b6bb22c06ac305912674"
+source = "git+https://github.com/egraphs-good/egglog?rev=15eec00#15eec00c5a8eed0d88b8277be3aa5c0c7b4ed3f7"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "2.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-can-stop-report#ebba7bb902bdc1b0f377b6bb22c06ac305912674"
+source = "git+https://github.com/egraphs-good/egglog?rev=15eec00#15eec00c5a8eed0d88b8277be3aa5c0c7b4ed3f7"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -457,7 +457,7 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "2.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-can-stop-report#ebba7bb902bdc1b0f377b6bb22c06ac305912674"
+source = "git+https://github.com/egraphs-good/egglog?rev=15eec00#15eec00c5a8eed0d88b8277be3aa5c0c7b4ed3f7"
 dependencies = [
  "rayon",
 ]
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "egglog-reports"
 version = "2.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-can-stop-report#ebba7bb902bdc1b0f377b6bb22c06ac305912674"
+source = "git+https://github.com/egraphs-good/egglog?rev=15eec00#15eec00c5a8eed0d88b8277be3aa5c0c7b4ed3f7"
 dependencies = [
  "clap",
  "hashbrown 0.16.0",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "2.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?branch=codex%2Fsplit-scheduler-can-stop-report#ebba7bb902bdc1b0f377b6bb22c06ac305912674"
+source = "git+https://github.com/egraphs-good/egglog?rev=15eec00#15eec00c5a8eed0d88b8277be3aa5c0c7b4ed3f7"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=3b58f8b#3b58f8b5fa3b7ad5899989b9d35bf9812ac12890"
+source = "git+https://github.com/egraphs-good/egglog?rev=3783b4f3#3783b4f38997a9e80f1c0482188e3fd04bc0b488"
 dependencies = [
  "chrono",
  "clap",
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=3b58f8b#3b58f8b5fa3b7ad5899989b9d35bf9812ac12890"
+source = "git+https://github.com/egraphs-good/egglog?rev=3783b4f3#3783b4f38997a9e80f1c0482188e3fd04bc0b488"
 dependencies = [
  "quote",
  "syn 2.0.108",
@@ -371,7 +371,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=3b58f8b#3b58f8b5fa3b7ad5899989b9d35bf9812ac12890"
+source = "git+https://github.com/egraphs-good/egglog?rev=3783b4f3#3783b4f38997a9e80f1c0482188e3fd04bc0b488"
 dependencies = [
  "ordered-float",
 ]
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=3b58f8b#3b58f8b5fa3b7ad5899989b9d35bf9812ac12890"
+source = "git+https://github.com/egraphs-good/egglog?rev=3783b4f3#3783b4f38997a9e80f1c0482188e3fd04bc0b488"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -402,7 +402,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=3b58f8b#3b58f8b5fa3b7ad5899989b9d35bf9812ac12890"
+source = "git+https://github.com/egraphs-good/egglog?rev=3783b4f3#3783b4f38997a9e80f1c0482188e3fd04bc0b488"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=3b58f8b#3b58f8b5fa3b7ad5899989b9d35bf9812ac12890"
+source = "git+https://github.com/egraphs-good/egglog?rev=3783b4f3#3783b4f38997a9e80f1c0482188e3fd04bc0b488"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -457,7 +457,7 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=3b58f8b#3b58f8b5fa3b7ad5899989b9d35bf9812ac12890"
+source = "git+https://github.com/egraphs-good/egglog?rev=3783b4f3#3783b4f38997a9e80f1c0482188e3fd04bc0b488"
 dependencies = [
  "rayon",
 ]
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "egglog-reports"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=3b58f8b#3b58f8b5fa3b7ad5899989b9d35bf9812ac12890"
+source = "git+https://github.com/egraphs-good/egglog?rev=3783b4f3#3783b4f38997a9e80f1c0482188e3fd04bc0b488"
 dependencies = [
  "clap",
  "hashbrown 0.16.0",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=3b58f8b#3b58f8b5fa3b7ad5899989b9d35bf9812ac12890"
+source = "git+https://github.com/egraphs-good/egglog?rev=3783b4f3#3783b4f38997a9e80f1c0482188e3fd04bc0b488"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=e434cf6#e434cf629696506ac799fc0b2ebb7eff9e995913"
+source = "git+https://github.com/egraphs-good/egglog?rev=82d8c718#82d8c718a55306c403afea0e11d36b861bd1a9da"
 dependencies = [
  "chrono",
  "clap",
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=e434cf6#e434cf629696506ac799fc0b2ebb7eff9e995913"
+source = "git+https://github.com/egraphs-good/egglog?rev=82d8c718#82d8c718a55306c403afea0e11d36b861bd1a9da"
 dependencies = [
  "quote",
  "syn 2.0.108",
@@ -371,7 +371,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=e434cf6#e434cf629696506ac799fc0b2ebb7eff9e995913"
+source = "git+https://github.com/egraphs-good/egglog?rev=82d8c718#82d8c718a55306c403afea0e11d36b861bd1a9da"
 dependencies = [
  "ordered-float",
 ]
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=e434cf6#e434cf629696506ac799fc0b2ebb7eff9e995913"
+source = "git+https://github.com/egraphs-good/egglog?rev=82d8c718#82d8c718a55306c403afea0e11d36b861bd1a9da"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -402,7 +402,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=e434cf6#e434cf629696506ac799fc0b2ebb7eff9e995913"
+source = "git+https://github.com/egraphs-good/egglog?rev=82d8c718#82d8c718a55306c403afea0e11d36b861bd1a9da"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=e434cf6#e434cf629696506ac799fc0b2ebb7eff9e995913"
+source = "git+https://github.com/egraphs-good/egglog?rev=82d8c718#82d8c718a55306c403afea0e11d36b861bd1a9da"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -457,7 +457,7 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=e434cf6#e434cf629696506ac799fc0b2ebb7eff9e995913"
+source = "git+https://github.com/egraphs-good/egglog?rev=82d8c718#82d8c718a55306c403afea0e11d36b861bd1a9da"
 dependencies = [
  "rayon",
 ]
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "egglog-reports"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=e434cf6#e434cf629696506ac799fc0b2ebb7eff9e995913"
+source = "git+https://github.com/egraphs-good/egglog?rev=82d8c718#82d8c718a55306c403afea0e11d36b861bd1a9da"
 dependencies = [
  "clap",
  "hashbrown 0.16.0",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=e434cf6#e434cf629696506ac799fc0b2ebb7eff9e995913"
+source = "git+https://github.com/egraphs-good/egglog?rev=82d8c718#82d8c718a55306c403afea0e11d36b861bd1a9da"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=15eec00#15eec00c5a8eed0d88b8277be3aa5c0c7b4ed3f7"
+source = "git+https://github.com/egraphs-good/egglog?rev=e434cf6#e434cf629696506ac799fc0b2ebb7eff9e995913"
 dependencies = [
  "chrono",
  "clap",
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=15eec00#15eec00c5a8eed0d88b8277be3aa5c0c7b4ed3f7"
+source = "git+https://github.com/egraphs-good/egglog?rev=e434cf6#e434cf629696506ac799fc0b2ebb7eff9e995913"
 dependencies = [
  "quote",
  "syn 2.0.108",
@@ -371,7 +371,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=15eec00#15eec00c5a8eed0d88b8277be3aa5c0c7b4ed3f7"
+source = "git+https://github.com/egraphs-good/egglog?rev=e434cf6#e434cf629696506ac799fc0b2ebb7eff9e995913"
 dependencies = [
  "ordered-float",
 ]
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=15eec00#15eec00c5a8eed0d88b8277be3aa5c0c7b4ed3f7"
+source = "git+https://github.com/egraphs-good/egglog?rev=e434cf6#e434cf629696506ac799fc0b2ebb7eff9e995913"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -402,7 +402,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=15eec00#15eec00c5a8eed0d88b8277be3aa5c0c7b4ed3f7"
+source = "git+https://github.com/egraphs-good/egglog?rev=e434cf6#e434cf629696506ac799fc0b2ebb7eff9e995913"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=15eec00#15eec00c5a8eed0d88b8277be3aa5c0c7b4ed3f7"
+source = "git+https://github.com/egraphs-good/egglog?rev=e434cf6#e434cf629696506ac799fc0b2ebb7eff9e995913"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -457,7 +457,7 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=15eec00#15eec00c5a8eed0d88b8277be3aa5c0c7b4ed3f7"
+source = "git+https://github.com/egraphs-good/egglog?rev=e434cf6#e434cf629696506ac799fc0b2ebb7eff9e995913"
 dependencies = [
  "rayon",
 ]
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "egglog-reports"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=15eec00#15eec00c5a8eed0d88b8277be3aa5c0c7b4ed3f7"
+source = "git+https://github.com/egraphs-good/egglog?rev=e434cf6#e434cf629696506ac799fc0b2ebb7eff9e995913"
 dependencies = [
  "clap",
  "hashbrown 0.16.0",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=15eec00#15eec00c5a8eed0d88b8277be3aa5c0c7b4ed3f7"
+source = "git+https://github.com/egraphs-good/egglog?rev=e434cf6#e434cf629696506ac799fc0b2ebb7eff9e995913"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=82d8c718#82d8c718a55306c403afea0e11d36b861bd1a9da"
+source = "git+https://github.com/egraphs-good/egglog?rev=3b58f8b#3b58f8b5fa3b7ad5899989b9d35bf9812ac12890"
 dependencies = [
  "chrono",
  "clap",
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=82d8c718#82d8c718a55306c403afea0e11d36b861bd1a9da"
+source = "git+https://github.com/egraphs-good/egglog?rev=3b58f8b#3b58f8b5fa3b7ad5899989b9d35bf9812ac12890"
 dependencies = [
  "quote",
  "syn 2.0.108",
@@ -371,7 +371,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=82d8c718#82d8c718a55306c403afea0e11d36b861bd1a9da"
+source = "git+https://github.com/egraphs-good/egglog?rev=3b58f8b#3b58f8b5fa3b7ad5899989b9d35bf9812ac12890"
 dependencies = [
  "ordered-float",
 ]
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=82d8c718#82d8c718a55306c403afea0e11d36b861bd1a9da"
+source = "git+https://github.com/egraphs-good/egglog?rev=3b58f8b#3b58f8b5fa3b7ad5899989b9d35bf9812ac12890"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -402,7 +402,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=82d8c718#82d8c718a55306c403afea0e11d36b861bd1a9da"
+source = "git+https://github.com/egraphs-good/egglog?rev=3b58f8b#3b58f8b5fa3b7ad5899989b9d35bf9812ac12890"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=82d8c718#82d8c718a55306c403afea0e11d36b861bd1a9da"
+source = "git+https://github.com/egraphs-good/egglog?rev=3b58f8b#3b58f8b5fa3b7ad5899989b9d35bf9812ac12890"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -457,7 +457,7 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=82d8c718#82d8c718a55306c403afea0e11d36b861bd1a9da"
+source = "git+https://github.com/egraphs-good/egglog?rev=3b58f8b#3b58f8b5fa3b7ad5899989b9d35bf9812ac12890"
 dependencies = [
  "rayon",
 ]
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "egglog-reports"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=82d8c718#82d8c718a55306c403afea0e11d36b861bd1a9da"
+source = "git+https://github.com/egraphs-good/egglog?rev=3b58f8b#3b58f8b5fa3b7ad5899989b9d35bf9812ac12890"
 dependencies = [
  "clap",
  "hashbrown 0.16.0",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog?rev=82d8c718#82d8c718a55306c403afea0e11d36b861bd1a9da"
+source = "git+https://github.com/egraphs-good/egglog?rev=3b58f8b#3b58f8b5fa3b7ad5899989b9d35bf9812ac12890"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { git = "https://github.com/saulshanabrook/egg-smol.git", branch = "codex/split-scheduler-can-stop-report", default-features = false }
-egglog-ast = { git = "https://github.com/saulshanabrook/egg-smol.git", branch = "codex/split-scheduler-can-stop-report", default-features = false }
-egglog-reports = { git = "https://github.com/saulshanabrook/egg-smol.git", branch = "codex/split-scheduler-can-stop-report", default-features = false }
+egglog = { git = "https://github.com/egraphs-good/egglog", rev = "15eec00", default-features = false }
+egglog-ast = { git = "https://github.com/egraphs-good/egglog", rev = "15eec00", default-features = false }
+egglog-reports = { git = "https://github.com/egraphs-good/egglog", rev = "15eec00", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { git = "https://github.com/egraphs-good/egglog", rev = "82d8c718", default-features = false }
-egglog-ast = { git = "https://github.com/egraphs-good/egglog", rev = "82d8c718", default-features = false }
-egglog-reports = { git = "https://github.com/egraphs-good/egglog", rev = "82d8c718", default-features = false }
+egglog = { git = "https://github.com/egraphs-good/egglog", rev = "3b58f8b", default-features = false }
+egglog-ast = { git = "https://github.com/egraphs-good/egglog", rev = "3b58f8b", default-features = false }
+egglog-reports = { git = "https://github.com/egraphs-good/egglog", rev = "3b58f8b", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { git = "https://github.com/egraphs-good/egglog", rev = "e434cf6", default-features = false }
-egglog-ast = { git = "https://github.com/egraphs-good/egglog", rev = "e434cf6", default-features = false }
-egglog-reports = { git = "https://github.com/egraphs-good/egglog", rev = "e434cf6", default-features = false }
+egglog = { git = "https://github.com/egraphs-good/egglog", rev = "82d8c718", default-features = false }
+egglog-ast = { git = "https://github.com/egraphs-good/egglog", rev = "82d8c718", default-features = false }
+egglog-reports = { git = "https://github.com/egraphs-good/egglog", rev = "82d8c718", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { git = "https://github.com/egraphs-good/egglog", rev = "15eec00", default-features = false }
-egglog-ast = { git = "https://github.com/egraphs-good/egglog", rev = "15eec00", default-features = false }
-egglog-reports = { git = "https://github.com/egraphs-good/egglog", rev = "15eec00", default-features = false }
+egglog = { git = "https://github.com/egraphs-good/egglog", rev = "e434cf6", default-features = false }
+egglog-ast = { git = "https://github.com/egraphs-good/egglog", rev = "e434cf6", default-features = false }
+egglog-reports = { git = "https://github.com/egraphs-good/egglog", rev = "e434cf6", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { git = "https://github.com/egraphs-good/egglog", rev = "3b58f8b", default-features = false }
-egglog-ast = { git = "https://github.com/egraphs-good/egglog", rev = "3b58f8b", default-features = false }
-egglog-reports = { git = "https://github.com/egraphs-good/egglog", rev = "3b58f8b", default-features = false }
+egglog = { git = "https://github.com/egraphs-good/egglog", rev = "3783b4f3", default-features = false }
+egglog-ast = { git = "https://github.com/egraphs-good/egglog", rev = "3783b4f3", default-features = false }
+egglog-reports = { git = "https://github.com/egraphs-good/egglog", rev = "3783b4f3", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 WWW=${PWD}/target/www/
 
-all: test nits docs
+all: test fixnits nits docs
 
 test:
 	cargo nextest run --release
@@ -12,6 +12,12 @@ nits:
 	cargo clippy --tests -- -D warnings
 	@rustup component add rustfmt
 	cargo fmt --check
+
+fixnits:
+	@rustup component add rustfmt
+	cargo fmt
+	@rustup component add rustfmt
+	cargo clippy --fix --tests --workspace --allow-dirty
 
 docs:
 	mkdir -p ${WWW}

--- a/src/keep_best.rs
+++ b/src/keep_best.rs
@@ -9,10 +9,8 @@
 
 use egglog::{
     ArcSort, CommandOutput, EGraph, Error, TermDag, TermId, TypeError, UserDefinedCommand, Value,
-    Write,
     ast::Expr,
     extract::{Extractor, TreeAdditiveCostModel},
-    prelude::{RustSpan, Span},
     sort::S,
 };
 
@@ -51,7 +49,7 @@ impl UserDefinedCommand for KeepBestCommand {
         egraph.with_full_state(|mut state| {
             for (name, _, keys) in &all_keys {
                 for key in keys {
-                    state.remove(name, key);
+                    egglog::Write::remove(&mut state, name, key);
                 }
             }
         });
@@ -69,7 +67,7 @@ impl UserDefinedCommand for KeepBestCommand {
 
         egraph.with_full_state(|mut state| {
             for (table_name, values) in &rows_to_insert {
-                state.insert(table_name, values.iter().copied());
+                egglog::Write::insert(&mut state, table_name, values.iter().copied());
             }
         });
 
@@ -91,7 +89,16 @@ fn collect_and_extract(
     for table_name in table_names {
         let func = egraph
             .get_function(table_name)
-            .ok_or_else(|| TypeError::UnboundFunction(table_name.clone(), egglog::span!()))?;
+            .ok_or_else(|| {
+                TypeError::UnboundFunction(
+                    table_name.clone(),
+                    egglog::prelude::Span::Rust(std::sync::Arc::new(egglog::prelude::RustSpan {
+                        file: file!(),
+                        line: line!(),
+                        column: column!(),
+                    })),
+                )
+            })?;
 
         let all_sorts: Vec<ArcSort> = func
             .schema()
@@ -145,7 +152,14 @@ fn eval_terms(
     term_ids
         .iter()
         .map(|tid| {
-            let expr = termdag.term_to_expr(tid, egglog::span!());
+            let expr = termdag.term_to_expr(
+                tid,
+                egglog::prelude::Span::Rust(std::sync::Arc::new(egglog::prelude::RustSpan {
+                    file: file!(),
+                    line: line!(),
+                    column: column!(),
+                })),
+            );
             let (_, val) = egraph.eval_expr(&expr)?;
             Ok(val)
         })

--- a/src/keep_best.rs
+++ b/src/keep_best.rs
@@ -31,28 +31,16 @@ impl UserDefinedCommand for KeepBestCommand {
         // term for every column value.
         let extracted = collect_and_extract(egraph, &table_names)?;
 
-        // Step 3: collect all input keys for every function, then clear all
-        // tables in one batched with_full_state call.
+        // Step 3: clear every function in the e-graph in bulk.
+        //
+        // `clear_function` drops the entire row buffer for a table in
+        // O(1)-in-row-count time and bumps the table's generation so cached
+        // indexes/subsets are lazily rebuilt. That's strictly faster than
+        // staging a `remove` per row, which is what we used to do here.
         let all_funcs: Vec<String> = egraph.get_function_names();
-        let all_keys: Vec<(String, usize, Vec<Vec<Value>>)> = all_funcs
-            .iter()
-            .map(|name| {
-                let n_inputs = egraph.get_function(name).unwrap().schema().input.len();
-                let mut keys: Vec<Vec<Value>> = Vec::new();
-                egraph.function_for_each(name, |row| {
-                    keys.push(row.vals[..n_inputs].to_vec());
-                })?;
-                Ok((name.clone(), n_inputs, keys))
-            })
-            .collect::<Result<_, Error>>()?;
-
-        egraph.with_full_state(|mut state| {
-            for (name, _, keys) in &all_keys {
-                for key in keys {
-                    egglog::Write::remove(&mut state, name, key);
-                }
-            }
-        });
+        for name in &all_funcs {
+            egraph.clear_function(name)?;
+        }
 
         // Step 4: re-insert the optimal tuples. Evaluate each extracted term
         // via eval_expr so that constructor sub-terms are re-created bottom-up,

--- a/src/keep_best.rs
+++ b/src/keep_best.rs
@@ -8,8 +8,8 @@
 //! Each argument must evaluate to a `String` that names an existing function.
 
 use egglog::{
-    ArcSort, CommandOutput, EGraph, Error, TermDag, TermId, TypeError, UserDefinedCommand,
-    Value, Write,
+    ArcSort, CommandOutput, EGraph, Error, TermDag, TermId, TypeError, UserDefinedCommand, Value,
+    Write,
     ast::Expr,
     extract::{Extractor, TreeAdditiveCostModel},
     prelude::{RustSpan, Span},
@@ -77,13 +77,15 @@ impl UserDefinedCommand for KeepBestCommand {
     }
 }
 
+type ExtractedTable = (String, Vec<Vec<TermId>>, TermDag);
+
 /// For each table, collect all rows and extract the best term for each value.
 /// Returns `(table_name, rows, termdag)` triples where each row is a list of
 /// `TermId`s (inputs followed by output) into the shared `termdag`.
 fn collect_and_extract(
     egraph: &EGraph,
     table_names: &[String],
-) -> Result<Vec<(String, Vec<Vec<TermId>>, TermDag)>, Error> {
+) -> Result<Vec<ExtractedTable>, Error> {
     let mut result = Vec::new();
 
     for table_name in table_names {

--- a/src/keep_best.rs
+++ b/src/keep_best.rs
@@ -19,7 +19,7 @@ use egglog::{
 pub struct KeepBestCommand;
 
 impl UserDefinedCommand for KeepBestCommand {
-    fn update(&self, egraph: &mut EGraph, args: &[Expr]) -> Result<Option<CommandOutput>, Error> {
+    fn update(&self, egraph: &mut EGraph, args: &[Expr]) -> Result<Vec<CommandOutput>, Error> {
         // Step 1: evaluate each argument to a table name string.
         let table_names: Vec<String> = args
             .iter()
@@ -73,7 +73,7 @@ impl UserDefinedCommand for KeepBestCommand {
             }
         });
 
-        Ok(None)
+        Ok(vec![])
     }
 }
 

--- a/src/keep_best.rs
+++ b/src/keep_best.rs
@@ -1,0 +1,151 @@
+//! Implementation of the `keep-best` command.
+//!
+//! `(keep-best "table1" "table2" ...)` extracts the optimal representative
+//! term for every entry in each named table, clears the entire e-graph, and
+//! re-inserts only those optimal tuples.  This "compacts" the e-graph to the
+//! best solutions found so far.
+//!
+//! Each argument must evaluate to a `String` that names an existing function.
+
+use egglog::{
+    ArcSort, CommandOutput, EGraph, Error, TermDag, TermId, TypeError, UserDefinedCommand,
+    Value, Write,
+    ast::Expr,
+    extract::{Extractor, TreeAdditiveCostModel},
+    prelude::{RustSpan, Span},
+    sort::S,
+};
+
+pub struct KeepBestCommand;
+
+impl UserDefinedCommand for KeepBestCommand {
+    fn update(&self, egraph: &mut EGraph, args: &[Expr]) -> Result<Option<CommandOutput>, Error> {
+        // Step 1: evaluate each argument to a table name string.
+        let table_names: Vec<String> = args
+            .iter()
+            .map(|arg| {
+                let (_, val) = egraph.eval_expr(arg)?;
+                Ok(egraph.value_to_base::<S>(val).0)
+            })
+            .collect::<Result<_, Error>>()?;
+
+        // Step 2: for each table, collect all rows and extract the optimal
+        // term for every column value.
+        let extracted = collect_and_extract(egraph, &table_names)?;
+
+        // Step 3: collect all input keys for every function, then clear all
+        // tables in one batched with_full_state call.
+        let all_funcs: Vec<String> = egraph.get_function_names();
+        let all_keys: Vec<(String, usize, Vec<Vec<Value>>)> = all_funcs
+            .iter()
+            .map(|name| {
+                let n_inputs = egraph.get_function(name).unwrap().schema().input.len();
+                let mut keys: Vec<Vec<Value>> = Vec::new();
+                egraph.function_for_each(name, |row| {
+                    keys.push(row.vals[..n_inputs].to_vec());
+                })?;
+                Ok((name.clone(), n_inputs, keys))
+            })
+            .collect::<Result<_, Error>>()?;
+
+        egraph.with_full_state(|mut state| {
+            for (name, _, keys) in &all_keys {
+                for key in keys {
+                    state.remove(name, key);
+                }
+            }
+        });
+
+        // Step 4: re-insert the optimal tuples. Evaluate each extracted term
+        // via eval_expr so that constructor sub-terms are re-created bottom-up,
+        // then stage all target-table inserts in one with_full_state call.
+        let mut rows_to_insert: Vec<(String, Vec<Value>)> = Vec::new();
+        for (table_name, extracted_rows, termdag) in &extracted {
+            for term_ids in extracted_rows {
+                let values = eval_terms(egraph, termdag, term_ids)?;
+                rows_to_insert.push((table_name.clone(), values));
+            }
+        }
+
+        egraph.with_full_state(|mut state| {
+            for (table_name, values) in &rows_to_insert {
+                state.insert(table_name, values.iter().copied());
+            }
+        });
+
+        Ok(None)
+    }
+}
+
+/// For each table, collect all rows and extract the best term for each value.
+/// Returns `(table_name, rows, termdag)` triples where each row is a list of
+/// `TermId`s (inputs followed by output) into the shared `termdag`.
+fn collect_and_extract(
+    egraph: &EGraph,
+    table_names: &[String],
+) -> Result<Vec<(String, Vec<Vec<TermId>>, TermDag)>, Error> {
+    let mut result = Vec::new();
+
+    for table_name in table_names {
+        let func = egraph
+            .get_function(table_name)
+            .ok_or_else(|| TypeError::UnboundFunction(table_name.clone(), egglog::span!()))?;
+
+        let all_sorts: Vec<ArcSort> = func
+            .schema()
+            .input
+            .iter()
+            .chain(std::iter::once(&func.schema().output))
+            .cloned()
+            .collect();
+
+        let mut raw_rows: Vec<Vec<Value>> = Vec::new();
+        egraph.function_for_each(table_name, |row| {
+            raw_rows.push(row.vals.to_vec());
+        })?;
+
+        let extractor = Extractor::compute_costs_from_rootsorts(
+            Some(all_sorts.clone()),
+            egraph,
+            TreeAdditiveCostModel::default(),
+        );
+        let mut termdag = TermDag::default();
+        let mut extracted_rows: Vec<Vec<TermId>> = Vec::new();
+
+        for row_vals in &raw_rows {
+            let mut term_ids = Vec::new();
+            for (val, sort) in row_vals.iter().zip(all_sorts.iter()) {
+                let (_, tid) = extractor
+                    .extract_best_with_sort(egraph, &mut termdag, *val, sort.clone())
+                    .ok_or_else(|| {
+                        Error::ExtractError(format!(
+                            "keep-best: could not extract value in table {table_name}"
+                        ))
+                    })?;
+                term_ids.push(tid);
+            }
+            extracted_rows.push(term_ids);
+        }
+
+        result.push((table_name.clone(), extracted_rows, termdag));
+    }
+
+    Ok(result)
+}
+
+/// Evaluate a list of `TermId`s from `termdag` using `eval_expr`, returning
+/// the resulting `Value`s in the same order.
+fn eval_terms(
+    egraph: &mut EGraph,
+    termdag: &TermDag,
+    term_ids: &[TermId],
+) -> Result<Vec<Value>, Error> {
+    term_ids
+        .iter()
+        .map(|tid| {
+            let expr = termdag.term_to_expr(tid, egglog::span!());
+            let (_, val) = egraph.eval_expr(&expr)?;
+            Ok(val)
+        })
+        .collect()
+}

--- a/src/keep_best.rs
+++ b/src/keep_best.rs
@@ -12,6 +12,7 @@ use egglog::{
     ast::Expr,
     extract::{Extractor, TreeAdditiveCostModel},
     sort::S,
+    span,
 };
 
 pub struct KeepBestCommand;
@@ -77,16 +78,7 @@ fn collect_and_extract(
     for table_name in table_names {
         let func = egraph
             .get_function(table_name)
-            .ok_or_else(|| {
-                TypeError::UnboundFunction(
-                    table_name.clone(),
-                    egglog::prelude::Span::Rust(std::sync::Arc::new(egglog::prelude::RustSpan {
-                        file: file!(),
-                        line: line!(),
-                        column: column!(),
-                    })),
-                )
-            })?;
+            .ok_or_else(|| TypeError::UnboundFunction(table_name.clone(), span!()))?;
 
         let all_sorts: Vec<ArcSort> = func
             .schema()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub fn new_experimental_egraph() -> EGraph {
     egraph
         .add_command(
             "run-schedule".into(),
-            Arc::new(RunExtendedSchedule::default()),
+            Arc::new(RunExtendedSchedule),
         )
         .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@
 //!   (see [`rational`] for the exposed primitives)
 //! - [Dynamic cost models with `set-cost`](https://egraphs-good.github.io/egglog-demo/?example=05-cost-model-and-extraction)
 //! - [Custom schedulers via `run-with`](https://egraphs-good.github.io/egglog-demo/?example=math-backoff)
+//! - An extended `run-schedule` command (see [`scheduling`]) with `seq`,                             
+//!   `saturate`, `repeat`, `eval`, and forwarded commands            
 //! - [`(get-size!)` primitive](https://github.com/egraphs-good/egglog-experimental/blob/main/tests/web-demo/node-limit.egg)
 //!   for inspecting total tuple counts or counts for specific tables
 //! - [Multi-extraction](https://github.com/egraphs-good/egglog-experimental/blob/main/tests/web-demo/multi-extract.egg)
@@ -27,7 +29,7 @@ use std::sync::Arc;
 
 pub mod rational;
 pub use rational::*;
-mod scheduling;
+pub mod scheduling;
 pub use scheduling::*;
 mod fresh_macro;
 
@@ -65,10 +67,7 @@ pub fn new_experimental_egraph() -> EGraph {
 
     // scheduler support
     egraph
-        .add_command(
-            "run-schedule".into(),
-            Arc::new(RunExtendedSchedule),
-        )
+        .add_command("run-schedule".into(), Arc::new(RunExtendedSchedule))
         .unwrap();
 
     egraph

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! The rest of this crate exposes the Rust APIs and helpers that back these extensions.
 //!
 use egglog::ast::Parser;
-use egglog::prelude::{RustSpan, Span, add_base_sort};
+use egglog::prelude::add_base_sort;
 pub use egglog::*;
 use std::sync::Arc;
 
@@ -65,7 +65,10 @@ pub fn new_experimental_egraph() -> EGraph {
 
     // scheduler support
     egraph
-        .add_command("run-schedule".into(), Arc::new(RunExtendedSchedule))
+        .add_command(
+            "run-schedule".into(),
+            Arc::new(RunExtendedSchedule::default()),
+        )
         .unwrap();
 
     egraph

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,9 @@ pub use size::*;
 mod sugar;
 pub use sugar::*;
 
+mod keep_best;
+pub use keep_best::KeepBestCommand;
+
 pub fn new_experimental_egraph() -> EGraph {
     let mut egraph = EGraph::default();
 
@@ -71,6 +74,11 @@ pub fn new_experimental_egraph() -> EGraph {
             Arc::new(MultiExtract::new(DynamicCostModel)),
         )
         .unwrap();
+
+    egraph
+        .add_command("keep-best".into(), Arc::new(KeepBestCommand))
+        .unwrap();
+
     egraph
 }
 

--- a/src/multi_extract.rs
+++ b/src/multi_extract.rs
@@ -56,7 +56,7 @@ impl<
     CM: CostModel<C> + Clone + Send + Sync + 'static,
 > UserDefinedCommand for MultiExtract<C, CM>
 {
-    fn update(&self, egraph: &mut EGraph, args: &[Expr]) -> Result<Option<CommandOutput>, Error> {
+    fn update(&self, egraph: &mut EGraph, args: &[Expr]) -> Result<Vec<CommandOutput>, Error> {
         assert!(args.len() >= 2);
 
         let (variants_sort, variants_value) = egraph.eval_expr(&args[0])?;
@@ -105,8 +105,8 @@ impl<
             );
         }
 
-        Ok(Some(CommandOutput::UserDefined(std::sync::Arc::from(
+        Ok(vec![CommandOutput::UserDefined(std::sync::Arc::from(
             MultiExtractOutput { termdag, terms },
-        ))))
+        ))])
     }
 }

--- a/src/multi_extract.rs
+++ b/src/multi_extract.rs
@@ -11,7 +11,7 @@ use egglog::{
     CommandOutput, EGraph, Error, TermDag, TermId, TypeError, UserDefinedCommand,
     ast::{Expr, ParseError},
     extract::{Cost, CostModel, Extractor},
-    prelude::{RustSpan, Span, span},
+    prelude::span,
 };
 use log::log_enabled;
 use std::{fmt::Debug, marker::PhantomData};

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -190,10 +190,29 @@ impl ScheduleState {
                     _ => err(),
                 }
             }
-            _ => Err(egglog::Error::ParseError(ParseError(
-                span.clone(),
-                "Invalid schedule".into(),
-            ))),
+            "call-prim" => match exprs.as_slice() {
+                [inner] => {
+                    egraph.eval_expr(inner)?;
+                    Ok(RunReport::default())
+                }
+                _ => err(),
+            },
+            _ => {
+                if egraph.has_command(head) {
+                    let output = egraph.run_user_defined_command(head, exprs)?;
+                    let report = if let Some(CommandOutput::RunSchedule(r)) = output {
+                        r
+                    } else {
+                        RunReport::default()
+                    };
+                    Ok(report)
+                } else {
+                    Err(egglog::Error::ParseError(ParseError(
+                        span.clone(),
+                        format!("Invalid schedule step: {head}"),
+                    )))
+                }
+            }
         }
     }
 }

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -1,45 +1,15 @@
-use std::{collections::HashMap, marker::PhantomData, sync::Mutex};
+use std::{collections::HashMap, sync::Mutex};
 
 use egglog::{
     CommandOutput, UserDefinedCommand,
-    ast::{Action, Change, Command, Expr, Fact, Literal, ParseError, PrintFunctionMode},
-    extract::{CostModel, DefaultCost, TreeAdditiveCostModel},
+    ast::{Command, Expr, Fact, Literal, ParseError},
     prelude::run_ruleset,
     scheduler::{Scheduler, SchedulerId},
 };
 use egglog_reports::RunReport;
 use lazy_static::lazy_static;
 
-use crate::extract_with_cost_model;
-
-pub struct RunExtendedSchedule<CM = TreeAdditiveCostModel>
-where
-    CM: CostModel<DefaultCost> + Clone + Send + Sync + 'static,
-{
-    cost_model: CM,
-    _cost: PhantomData<DefaultCost>,
-}
-
-impl Default for RunExtendedSchedule<TreeAdditiveCostModel> {
-    fn default() -> Self {
-        RunExtendedSchedule {
-            cost_model: TreeAdditiveCostModel::default(),
-            _cost: PhantomData,
-        }
-    }
-}
-
-impl<CM> RunExtendedSchedule<CM>
-where
-    CM: CostModel<DefaultCost> + Clone + Send + Sync + 'static,
-{
-    pub fn new(cost_model: CM) -> Self {
-        RunExtendedSchedule {
-            cost_model,
-            _cost: PhantomData,
-        }
-    }
-}
+pub struct RunExtendedSchedule;
 
 pub trait SchedulerGen {
     fn new_scheduler(&self, egraph: &egglog::EGraph, args: &[Expr]) -> Box<dyn Scheduler>;
@@ -47,9 +17,8 @@ pub trait SchedulerGen {
 
 type SchedulerBuilder = Box<dyn Fn(&egglog::EGraph, &[Expr]) -> Box<dyn Scheduler> + Send + Sync>;
 
-struct ScheduleState<CM: CostModel<DefaultCost> + Clone + 'static> {
+struct ScheduleState {
     schedulers: Vec<(String, SchedulerId)>,
-    cost_model: CM,
 }
 
 lazy_static! {
@@ -65,12 +34,9 @@ pub fn add_scheduler_builder(name: String, builder: SchedulerBuilder) {
     scheduler_libs.lock().unwrap().insert(name, builder);
 }
 
-impl<CM: CostModel<DefaultCost> + Clone + 'static> ScheduleState<CM> {
-    fn new(cost_model: CM) -> Self {
-        Self {
-            schedulers: vec![],
-            cost_model,
-        }
+impl ScheduleState {
+    fn new() -> Self {
+        Self { schedulers: vec![] }
     }
 
     // Current limitation: because it relies on the publicly available Rust APIs to access
@@ -111,14 +77,6 @@ impl<CM: CostModel<DefaultCost> + Clone + 'static> ScheduleState<CM> {
                 res
             }};
         }
-
-        // Run a single Command via run_program and return (outputs, empty RunReport).
-        let run_cmd = |egraph: &mut egglog::EGraph,
-                       cmd: Command|
-         -> Result<(Vec<CommandOutput>, RunReport), egglog::Error> {
-            let outputs = egraph.run_program(vec![cmd])?;
-            Ok((outputs, RunReport::default()))
-        };
 
         match head.as_str() {
             "let-scheduler" => match exprs.as_slice() {
@@ -242,144 +200,47 @@ impl<CM: CostModel<DefaultCost> + Clone + 'static> ScheduleState<CM> {
                 }
                 _ => err(),
             },
-            // print-size: (print-size) or (print-size FuncName)
-            "print-size" => match exprs.as_slice() {
-                [] => run_cmd(egraph, Command::PrintSize(span.clone(), None)),
-                [Expr::Var(_, name)] => {
-                    run_cmd(egraph, Command::PrintSize(span.clone(), Some(name.clone())))
-                }
-                _ => err(),
-            },
-            // print-function: (print-function FuncName) or (print-function FuncName n)
-            "print-function" => match exprs.as_slice() {
-                [Expr::Var(_, name)] => run_cmd(
-                    egraph,
-                    Command::PrintFunction(
-                        span.clone(),
-                        name.clone(),
-                        None,
-                        None,
-                        PrintFunctionMode::Default,
-                    ),
-                ),
-                [Expr::Var(_, name), Expr::Lit(_, Literal::Int(n))] => run_cmd(
-                    egraph,
-                    Command::PrintFunction(
-                        span.clone(),
-                        name.clone(),
-                        Some(*n as usize),
-                        None,
-                        PrintFunctionMode::Default,
-                    ),
-                ),
-                _ => err(),
-            },
-            // extract: (extract expr) or (extract expr n)
-            "extract" if matches!(exprs.len(), 1 | 2) => {
-                let outputs = extract_with_cost_model(egraph, exprs, self.cost_model.clone())?;
-                Ok((outputs, RunReport::default()))
-            }
-            "extract" => err(),
-            // push: (push) or (push n)
-            "push" => match exprs.as_slice() {
-                [] => run_cmd(egraph, Command::Push(1)),
-                [Expr::Lit(_, Literal::Int(n))] => run_cmd(egraph, Command::Push(*n as usize)),
-                _ => err(),
-            },
-            // pop: (pop) or (pop n)
-            "pop" => match exprs.as_slice() {
-                [] => run_cmd(egraph, Command::Pop(span.clone(), 1)),
-                [Expr::Lit(_, Literal::Int(n))] => {
-                    run_cmd(egraph, Command::Pop(span.clone(), *n as usize))
-                }
-                _ => err(),
-            },
-            // Non-let actions
-            "union" => match exprs.as_slice() {
-                [a, b] => run_cmd(
-                    egraph,
-                    Command::Action(Action::Union(span.clone(), a.clone(), b.clone())),
-                ),
-                _ => err(),
-            },
-            "set" => match exprs.as_slice() {
-                [Expr::Call(_, f, args), rhs] => run_cmd(
-                    egraph,
-                    Command::Action(Action::Set(
-                        span.clone(),
-                        f.clone(),
-                        args.clone(),
-                        rhs.clone(),
-                    )),
-                ),
-                _ => err(),
-            },
-            "delete" => match exprs.as_slice() {
-                [Expr::Call(_, f, args)] => run_cmd(
-                    egraph,
-                    Command::Action(Action::Change(
-                        span.clone(),
-                        Change::Delete,
-                        f.clone(),
-                        args.clone(),
-                    )),
-                ),
-                _ => err(),
-            },
-            "subsume" => match exprs.as_slice() {
-                [Expr::Call(_, f, args)] => run_cmd(
-                    egraph,
-                    Command::Action(Action::Change(
-                        span.clone(),
-                        Change::Subsume,
-                        f.clone(),
-                        args.clone(),
-                    )),
-                ),
-                _ => err(),
-            },
-            "panic" => match exprs.as_slice() {
-                [Expr::Lit(_, Literal::String(msg))] => run_cmd(
-                    egraph,
-                    Command::Action(Action::Panic(span.clone(), msg.clone())),
-                ),
-                _ => err(),
-            },
-            _ => {
-                if egraph.has_command(head) {
-                    let cmd_outputs = egraph.run_user_defined_command(head, exprs)?;
-                    let mut report = RunReport::default();
-                    let mut outputs = Vec::new();
-                    for output in cmd_outputs {
-                        if let CommandOutput::RunSchedule(r) = output {
-                            report.union(r);
-                        } else {
-                            outputs.push(output);
-                        }
+            // Allowlisted commands forwarded via parse roundtrip.
+            // User-defined commands are also allowed (run-schedule, multi-extract, keep-best, ...).
+            // Anything else (rule declarations, let bindings, function definitions, ...) is rejected.
+            _ if matches!(
+                head.as_str(),
+                "print-size"
+                    | "print-function"
+                    | "extract"
+                    | "push"
+                    | "pop"
+                    | "union"
+                    | "set"
+                    | "delete"
+                    | "subsume"
+                    | "panic"
+            ) || egraph.has_command(head) =>
+            {
+                let outputs = egraph.parse_and_run_program(None, &format!("{}", arg))?;
+                let mut report = RunReport::default();
+                let mut cmd_outputs = Vec::new();
+                for output in outputs {
+                    if let CommandOutput::RunSchedule(r) = output {
+                        report.union(r);
+                    } else {
+                        cmd_outputs.push(output);
                     }
-                    Ok((outputs, report))
-                } else {
-                    // General expression evaluation (supersedes call-prim)
-                    run_cmd(
-                        egraph,
-                        Command::Action(Action::Expr(span.clone(), arg.clone())),
-                    )
                 }
+                Ok((cmd_outputs, report))
             }
+            _ => err(),
         }
     }
 }
 
-impl<CM> UserDefinedCommand for RunExtendedSchedule<CM>
-where
-    CM: CostModel<DefaultCost> + Clone + Send + Sync + 'static,
-{
+impl UserDefinedCommand for RunExtendedSchedule {
     fn update(
         &self,
         egraph: &mut egglog::EGraph,
         args: &[Expr],
     ) -> Result<Vec<CommandOutput>, egglog::Error> {
-        let mut schedule = ScheduleState::new(self.cost_model.clone());
+        let mut schedule = ScheduleState::new();
         let mut report = RunReport::default();
         let mut outputs: Vec<CommandOutput> = Vec::new();
         for arg in args {

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -79,11 +79,12 @@ impl ScheduleState {
         }
 
         // Run a single Command via run_program and return (outputs, empty RunReport).
-        let run_cmd =
-            |egraph: &mut egglog::EGraph, cmd: Command| -> Result<(Vec<CommandOutput>, RunReport), egglog::Error> {
-                let outputs = egraph.run_program(vec![cmd])?;
-                Ok((outputs, RunReport::default()))
-            };
+        let run_cmd = |egraph: &mut egglog::EGraph,
+                       cmd: Command|
+         -> Result<(Vec<CommandOutput>, RunReport), egglog::Error> {
+            let outputs = egraph.run_program(vec![cmd])?;
+            Ok((outputs, RunReport::default()))
+        };
 
         match head.as_str() {
             "let-scheduler" => match exprs.as_slice() {

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Mutex};
 
 use egglog::{
     CommandOutput, UserDefinedCommand,
-    ast::{Command, Expr, Fact, Literal, ParseError},
+    ast::{Action, Change, Command, Expr, Fact, Literal, ParseError, PrintFunctionMode},
     prelude::run_ruleset,
     scheduler::{Scheduler, SchedulerId},
 };
@@ -44,7 +44,11 @@ impl ScheduleState {
     // - the same condition may be compiled and type checked multiple times
     // - the logging information may show that multiple schedules are run, but they
     //   are actually the same schedule.
-    fn run(&mut self, egraph: &mut egglog::EGraph, arg: &Expr) -> Result<RunReport, egglog::Error> {
+    fn run(
+        &mut self,
+        egraph: &mut egglog::EGraph,
+        arg: &Expr,
+    ) -> Result<(Vec<CommandOutput>, RunReport), egglog::Error> {
         let err = || {
             Err(egglog::Error::ParseError(ParseError(
                 arg.span(),
@@ -56,7 +60,7 @@ impl ScheduleState {
             let output = run_ruleset(egraph, ruleset.as_str())?;
             assert!(output.len() == 1);
             if let CommandOutput::RunSchedule(report) = &output[0] {
-                return Ok(report.clone());
+                return Ok((vec![], report.clone()));
             }
             panic!("Expected a RunSchedule, got {:?}", output[0]);
         }
@@ -68,11 +72,18 @@ impl ScheduleState {
         macro_rules! new_scope {
             ($f:expr) => {{
                 let curr_scope = self.schedulers.len();
-                let res: Result<RunReport, egglog::Error> = $f();
+                let res: Result<(Vec<CommandOutput>, RunReport), egglog::Error> = $f();
                 self.schedulers.truncate(curr_scope);
                 res
             }};
         }
+
+        // Run a single Command via run_program and return (outputs, empty RunReport).
+        let run_cmd =
+            |egraph: &mut egglog::EGraph, cmd: Command| -> Result<(Vec<CommandOutput>, RunReport), egglog::Error> {
+                let outputs = egraph.run_program(vec![cmd])?;
+                Ok((outputs, RunReport::default()))
+            };
 
         match head.as_str() {
             "let-scheduler" => match exprs.as_slice() {
@@ -87,7 +98,7 @@ impl ScheduleState {
                         (scheduler_libs.lock().unwrap().get(scheduler_name).unwrap())(egraph, args);
                     let id = egraph.add_scheduler(scheduler);
                     self.schedulers.push((name.clone(), id));
-                    Ok(RunReport::default())
+                    Ok((vec![], RunReport::default()))
                 }
                 _ => err(),
             },
@@ -128,89 +139,206 @@ impl ScheduleState {
                         .run_program(vec![Command::Check(span, vec![Fact::Fact(until)])])
                         .is_ok()
                     {
-                        return Ok(RunReport::default());
+                        return Ok((vec![], RunReport::default()));
                     }
                 }
 
-                if let Some(scheduler) = scheduler {
-                    egraph.step_rules_with_scheduler(scheduler, ruleset)
+                let report = if let Some(scheduler) = scheduler {
+                    egraph.step_rules_with_scheduler(scheduler, ruleset)?
                 } else {
-                    // Running the ruleset
-                    egraph.step_rules(ruleset)
-                }
+                    egraph.step_rules(ruleset)?
+                };
+                Ok((vec![], report))
             }
             "saturate" => {
+                let mut all_outputs: Vec<CommandOutput> = vec![];
                 let mut report = RunReport::default();
                 loop {
-                    let iter_report = new_scope!(|| {
+                    let (iter_outputs, iter_report) = new_scope!(|| {
+                        let mut iter_outputs: Vec<CommandOutput> = vec![];
                         let mut iter_report = RunReport::default();
                         for expr in exprs {
-                            let res = self.run(egraph, expr)?;
-                            iter_report.union(res);
+                            let (step_outputs, step_report) = self.run(egraph, expr)?;
+                            iter_outputs.extend(step_outputs);
+                            iter_report.union(step_report);
                         }
-                        Ok(iter_report)
+                        Ok((iter_outputs, iter_report))
                     })?;
                     let should_stop = iter_report.can_stop;
+                    all_outputs.extend(iter_outputs);
                     report.union(iter_report);
                     if should_stop {
                         break;
                     }
                 }
-                Ok(report)
+                Ok((all_outputs, report))
             }
             "seq" => {
                 new_scope!(|| {
+                    let mut all_outputs: Vec<CommandOutput> = vec![];
                     let mut report = RunReport::default();
                     for expr in exprs {
-                        // Recursively run each expression in the sequence
-                        let res = self.run(egraph, expr)?;
-                        report.union(res);
+                        let (step_outputs, step_report) = self.run(egraph, expr)?;
+                        all_outputs.extend(step_outputs);
+                        report.union(step_report);
                     }
-                    Ok(report)
+                    Ok((all_outputs, report))
                 })
             }
-            "repeat" => {
-                match exprs.as_slice() {
-                    [Expr::Lit(_span, Literal::Int(n)), rest @ ..] => {
-                        let mut report = RunReport::default();
-                        for _ in 0..*n {
-                            let sub_report = new_scope!(|| {
-                                let mut report = RunReport::default();
-                                // Recursively run the rest of the expressions
-                                for expr in rest {
-                                    let res = self.run(egraph, expr)?;
-                                    report.union(res);
-                                }
-                                Ok(report)
-                            })?;
-                            report.union(sub_report);
-                        }
-                        Ok(report)
+            "repeat" => match exprs.as_slice() {
+                [Expr::Lit(_span, Literal::Int(n)), rest @ ..] => {
+                    let mut all_outputs: Vec<CommandOutput> = vec![];
+                    let mut report = RunReport::default();
+                    for _ in 0..*n {
+                        let (iter_outputs, iter_report) = new_scope!(|| {
+                            let mut iter_outputs: Vec<CommandOutput> = vec![];
+                            let mut iter_report = RunReport::default();
+                            for expr in rest {
+                                let (step_outputs, step_report) = self.run(egraph, expr)?;
+                                iter_outputs.extend(step_outputs);
+                                iter_report.union(step_report);
+                            }
+                            Ok((iter_outputs, iter_report))
+                        })?;
+                        all_outputs.extend(iter_outputs);
+                        report.union(iter_report);
                     }
-                    _ => err(),
+                    Ok((all_outputs, report))
                 }
-            }
-            "call-prim" => match exprs.as_slice() {
-                [inner] => {
-                    egraph.eval_expr(inner)?;
-                    Ok(RunReport::default())
+                _ => err(),
+            },
+            // print-size: (print-size) or (print-size FuncName)
+            "print-size" => match exprs.as_slice() {
+                [] => run_cmd(egraph, Command::PrintSize(span.clone(), None)),
+                [Expr::Var(_, name)] => {
+                    run_cmd(egraph, Command::PrintSize(span.clone(), Some(name.clone())))
                 }
+                _ => err(),
+            },
+            // print-function: (print-function FuncName) or (print-function FuncName n)
+            "print-function" => match exprs.as_slice() {
+                [Expr::Var(_, name)] => run_cmd(
+                    egraph,
+                    Command::PrintFunction(
+                        span.clone(),
+                        name.clone(),
+                        None,
+                        None,
+                        PrintFunctionMode::Default,
+                    ),
+                ),
+                [Expr::Var(_, name), Expr::Lit(_, Literal::Int(n))] => run_cmd(
+                    egraph,
+                    Command::PrintFunction(
+                        span.clone(),
+                        name.clone(),
+                        Some(*n as usize),
+                        None,
+                        PrintFunctionMode::Default,
+                    ),
+                ),
+                _ => err(),
+            },
+            // extract: (extract expr) or (extract expr n)
+            "extract" => match exprs.as_slice() {
+                [expr] => run_cmd(
+                    egraph,
+                    Command::Extract(
+                        span.clone(),
+                        expr.clone(),
+                        Expr::Lit(span.clone(), Literal::Int(0)),
+                    ),
+                ),
+                [expr, n] => run_cmd(
+                    egraph,
+                    Command::Extract(span.clone(), expr.clone(), n.clone()),
+                ),
+                _ => err(),
+            },
+            // push: (push) or (push n)
+            "push" => match exprs.as_slice() {
+                [] => run_cmd(egraph, Command::Push(1)),
+                [Expr::Lit(_, Literal::Int(n))] => run_cmd(egraph, Command::Push(*n as usize)),
+                _ => err(),
+            },
+            // pop: (pop) or (pop n)
+            "pop" => match exprs.as_slice() {
+                [] => run_cmd(egraph, Command::Pop(span.clone(), 1)),
+                [Expr::Lit(_, Literal::Int(n))] => {
+                    run_cmd(egraph, Command::Pop(span.clone(), *n as usize))
+                }
+                _ => err(),
+            },
+            // Non-let actions
+            "union" => match exprs.as_slice() {
+                [a, b] => run_cmd(
+                    egraph,
+                    Command::Action(Action::Union(span.clone(), a.clone(), b.clone())),
+                ),
+                _ => err(),
+            },
+            "set" => match exprs.as_slice() {
+                [Expr::Call(_, f, args), rhs] => run_cmd(
+                    egraph,
+                    Command::Action(Action::Set(
+                        span.clone(),
+                        f.clone(),
+                        args.clone(),
+                        rhs.clone(),
+                    )),
+                ),
+                _ => err(),
+            },
+            "delete" => match exprs.as_slice() {
+                [Expr::Call(_, f, args)] => run_cmd(
+                    egraph,
+                    Command::Action(Action::Change(
+                        span.clone(),
+                        Change::Delete,
+                        f.clone(),
+                        args.clone(),
+                    )),
+                ),
+                _ => err(),
+            },
+            "subsume" => match exprs.as_slice() {
+                [Expr::Call(_, f, args)] => run_cmd(
+                    egraph,
+                    Command::Action(Action::Change(
+                        span.clone(),
+                        Change::Subsume,
+                        f.clone(),
+                        args.clone(),
+                    )),
+                ),
+                _ => err(),
+            },
+            "panic" => match exprs.as_slice() {
+                [Expr::Lit(_, Literal::String(msg))] => run_cmd(
+                    egraph,
+                    Command::Action(Action::Panic(span.clone(), msg.clone())),
+                ),
                 _ => err(),
             },
             _ => {
                 if egraph.has_command(head) {
-                    let output = egraph.run_user_defined_command(head, exprs)?;
-                    let report = if let Some(CommandOutput::RunSchedule(r)) = output {
-                        r
-                    } else {
-                        RunReport::default()
-                    };
-                    Ok(report)
+                    let cmd_outputs = egraph.run_user_defined_command(head, exprs)?;
+                    let mut report = RunReport::default();
+                    let mut outputs = Vec::new();
+                    for output in cmd_outputs {
+                        if let CommandOutput::RunSchedule(r) = output {
+                            report.union(r);
+                        } else {
+                            outputs.push(output);
+                        }
+                    }
+                    Ok((outputs, report))
                 } else {
-                    Err(egglog::Error::ParseError(ParseError(
-                        span.clone(),
-                        format!("Invalid schedule step: {head}"),
-                    )))
+                    // General expression evaluation (supersedes call-prim)
+                    run_cmd(
+                        egraph,
+                        Command::Action(Action::Expr(span.clone(), arg.clone())),
+                    )
                 }
             }
         }
@@ -222,13 +350,17 @@ impl UserDefinedCommand for RunExtendedSchedule {
         &self,
         egraph: &mut egglog::EGraph,
         args: &[Expr],
-    ) -> Result<Option<CommandOutput>, egglog::Error> {
+    ) -> Result<Vec<CommandOutput>, egglog::Error> {
         let mut schedule = ScheduleState::new();
         let mut report = RunReport::default();
+        let mut outputs: Vec<CommandOutput> = Vec::new();
         for arg in args {
-            report.union(schedule.run(egraph, arg)?);
+            let (step_outputs, step_report) = schedule.run(egraph, arg)?;
+            outputs.extend(step_outputs);
+            report.union(step_report);
         }
-        Ok(Some(CommandOutput::RunSchedule(report)))
+        outputs.push(CommandOutput::RunSchedule(report));
+        Ok(outputs)
     }
 }
 

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -1,15 +1,45 @@
-use std::{collections::HashMap, sync::Mutex};
+use std::{collections::HashMap, marker::PhantomData, sync::Mutex};
 
 use egglog::{
     CommandOutput, UserDefinedCommand,
     ast::{Action, Change, Command, Expr, Fact, Literal, ParseError, PrintFunctionMode},
+    extract::{CostModel, DefaultCost, TreeAdditiveCostModel},
     prelude::run_ruleset,
     scheduler::{Scheduler, SchedulerId},
 };
 use egglog_reports::RunReport;
 use lazy_static::lazy_static;
 
-pub struct RunExtendedSchedule;
+use crate::extract_with_cost_model;
+
+pub struct RunExtendedSchedule<CM = TreeAdditiveCostModel>
+where
+    CM: CostModel<DefaultCost> + Clone + Send + Sync + 'static,
+{
+    cost_model: CM,
+    _cost: PhantomData<DefaultCost>,
+}
+
+impl Default for RunExtendedSchedule<TreeAdditiveCostModel> {
+    fn default() -> Self {
+        RunExtendedSchedule {
+            cost_model: TreeAdditiveCostModel::default(),
+            _cost: PhantomData,
+        }
+    }
+}
+
+impl<CM> RunExtendedSchedule<CM>
+where
+    CM: CostModel<DefaultCost> + Clone + Send + Sync + 'static,
+{
+    pub fn new(cost_model: CM) -> Self {
+        RunExtendedSchedule {
+            cost_model,
+            _cost: PhantomData,
+        }
+    }
+}
 
 pub trait SchedulerGen {
     fn new_scheduler(&self, egraph: &egglog::EGraph, args: &[Expr]) -> Box<dyn Scheduler>;
@@ -17,8 +47,9 @@ pub trait SchedulerGen {
 
 type SchedulerBuilder = Box<dyn Fn(&egglog::EGraph, &[Expr]) -> Box<dyn Scheduler> + Send + Sync>;
 
-struct ScheduleState {
+struct ScheduleState<CM: CostModel<DefaultCost> + Clone + 'static> {
     schedulers: Vec<(String, SchedulerId)>,
+    cost_model: CM,
 }
 
 lazy_static! {
@@ -34,9 +65,12 @@ pub fn add_scheduler_builder(name: String, builder: SchedulerBuilder) {
     scheduler_libs.lock().unwrap().insert(name, builder);
 }
 
-impl ScheduleState {
-    fn new() -> Self {
-        Self { schedulers: vec![] }
+impl<CM: CostModel<DefaultCost> + Clone + 'static> ScheduleState<CM> {
+    fn new(cost_model: CM) -> Self {
+        Self {
+            schedulers: vec![],
+            cost_model,
+        }
     }
 
     // Current limitation: because it relies on the publicly available Rust APIs to access
@@ -241,21 +275,11 @@ impl ScheduleState {
                 _ => err(),
             },
             // extract: (extract expr) or (extract expr n)
-            "extract" => match exprs.as_slice() {
-                [expr] => run_cmd(
-                    egraph,
-                    Command::Extract(
-                        span.clone(),
-                        expr.clone(),
-                        Expr::Lit(span.clone(), Literal::Int(0)),
-                    ),
-                ),
-                [expr, n] => run_cmd(
-                    egraph,
-                    Command::Extract(span.clone(), expr.clone(), n.clone()),
-                ),
-                _ => err(),
-            },
+            "extract" if matches!(exprs.len(), 1 | 2) => {
+                let outputs = extract_with_cost_model(egraph, exprs, self.cost_model.clone())?;
+                Ok((outputs, RunReport::default()))
+            }
+            "extract" => err(),
             // push: (push) or (push n)
             "push" => match exprs.as_slice() {
                 [] => run_cmd(egraph, Command::Push(1)),
@@ -346,13 +370,16 @@ impl ScheduleState {
     }
 }
 
-impl UserDefinedCommand for RunExtendedSchedule {
+impl<CM> UserDefinedCommand for RunExtendedSchedule<CM>
+where
+    CM: CostModel<DefaultCost> + Clone + Send + Sync + 'static,
+{
     fn update(
         &self,
         egraph: &mut egglog::EGraph,
         args: &[Expr],
     ) -> Result<Vec<CommandOutput>, egglog::Error> {
-        let mut schedule = ScheduleState::new();
+        let mut schedule = ScheduleState::new(self.cost_model.clone());
         let mut report = RunReport::default();
         let mut outputs: Vec<CommandOutput> = Vec::new();
         for arg in args {

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -1,3 +1,54 @@
+//! The `run-schedule` command: an extended scheduling language for egglog.                           
+//!                                                                                                   
+//! `run-schedule` takes one or more *schedule expressions* and runs them in                          
+//! order against the e-graph, returning the combined [`RunReport`] (plus any                         
+//! per-command outputs such as `print-size` results). It is registered as a                          
+//! user-defined command by [`new_experimental_egraph`](crate::new_experimental_egraph)               
+//! and is the experimental counterpart to core egglog's built-in `run-schedule`.                     
+//!                                                                                                   
+//! # Schedule expressions                                                                            
+//!                                                                                                   
+//! A schedule expression is one of:                                                                  
+//!                                                                                                   
+//! - **`ruleset`** — a bare ruleset name (a [`Var`](egglog::ast::Expr::Var)),                        
+//!   e.g. `my-rules`. Runs one step of that ruleset.                                                 
+//! - **`(run [ruleset] [:until cond])`** — run one step of `ruleset` (or the                         
+//!   empty/default ruleset if omitted). With `:until cond`, the step is skipped                      
+//!   once `cond` already holds (`cond` is checked as a [`Check`](egglog::ast::Command::Check)).      
+//! - **`(run-with scheduler [ruleset] [:until cond])`** — like `run`, but drives                     
+//!   the ruleset with a named scheduler previously bound by `let-scheduler`.                         
+//! - **`(let-scheduler name (scheduler-kind args...))`** — bind `name` to a fresh                    
+//!   scheduler instance (e.g. `(back-off :match-limit 1000 :ban-length 5)`).                         
+//!   The binding is scoped to the enclosing `seq`/`saturate`/`repeat` block.                         
+//! - **`(seq step...)`** — run each step once, in order.                                             
+//! - **`(saturate step...)`** — repeatedly run the body until it makes no further                    
+//!   progress (the accumulated report's `can_stop` is set).                                          
+//! - **`(repeat n step...)`** — run the body `n` times.                                              
+//! - **`(eval expr...)`** — evaluate each `expr` in the full read/write                              
+//!   (FullState) context and add the resulting terms to the e-graph, the                             
+//!   schedule-step analogue of a top-level expression like `(Add (Num 1) (Num 2))`.                  
+//!   Because evaluation has full database access, the expressions may also call                      
+//!   reading primitives such as `(get-size!)` that are not admissible from an                        
+//!   ordinary action context.                                                                        
+//! - **A forwarded command** — a fixed allowlist of side-effecting commands                          
+//!   (`print-size`, `print-function`, `extract`, `push`, `pop`, `union`, `set`,                      
+//!   `delete`, `subsume`, `panic`) and any registered user-defined command                           
+//!   (e.g. `keep-best`, `multi-extract`, or a nested `run-schedule`). These are                      
+//!   forwarded by re-parsing the s-expression through                                                
+//!   [`parse_and_run_program`](egglog::EGraph::parse_and_run_program); any other                     
+//!   head (rule declarations, `let` bindings, function definitions, …) is rejected.                  
+//!                                                                                                   
+//! # Example                                                                                         
+//!                                                                                                   
+//! ```text                                                                                           
+//! (run-schedule                                                                                     
+//!   (repeat 3                                                                                       
+//!     (push)                                                                                        
+//!     (eval (Add (Num 1) (Num 2)))   ; add a term to the e-graph                                    
+//!     (saturate (run math-rules))    ; rewrite to fixpoint                                          
+//!     (keep-best "Target")           ; compact to best representatives                              
+//!     (pop)))                                                                                       
+//! ```                       
 use std::{collections::HashMap, sync::Mutex};
 
 use egglog::{
@@ -9,6 +60,9 @@ use egglog::{
 use egglog_reports::RunReport;
 use lazy_static::lazy_static;
 
+/// The `run-schedule` user-defined command.                                                          
+///                                                                                                   
+/// See the [module-level documentation](self) for the full schedule language.  
 pub struct RunExtendedSchedule;
 
 pub trait SchedulerGen {
@@ -230,6 +284,18 @@ impl ScheduleState {
                 }
                 _ => err(),
             },
+            // (eval <expr> ...): evaluate each expression and add the resulting
+            // terms to the e-graph — the schedule-step analogue of a top-level
+            // expression such as `(Add (Num 1) (Num 2))`. Evaluation happens in
+            // the full read/write (FullState) context, so the expressions may
+            // also call reading primitives like `(get-size!)` that are not
+            // admissible from an ordinary action context.
+            "eval" => {
+                for expr in exprs {
+                    egraph.eval_expr(expr)?;
+                }
+                Ok((vec![], RunReport::default()))
+            }
             // Allowlisted commands forwarded via parse roundtrip.
             // User-defined commands are also allowed (run-schedule, multi-extract, keep-best, ...).
             // Anything else (rule declarations, let bindings, function definitions, ...) is rejected.

--- a/src/set_cost.rs
+++ b/src/set_cost.rs
@@ -221,7 +221,7 @@ impl UserDefinedCommand for CustomExtract {
         &self,
         egraph: &mut EGraph,
         args: &[Expr],
-    ) -> Result<Option<CommandOutput>, egglog::Error> {
+    ) -> Result<Vec<CommandOutput>, egglog::Error> {
         assert!(args.len() <= 2);
         let (sort, value) = egraph.eval_expr(&args[0])?;
         let n = args.get(1).map(|arg| egraph.eval_expr(arg)).transpose()?;
@@ -252,7 +252,7 @@ impl UserDefinedCommand for CustomExtract {
                 if log_enabled!(log::Level::Info) {
                     log::info!("extracted with cost {cost}: {}", termdag.to_string(term));
                 }
-                Ok(Some(CommandOutput::ExtractBest(termdag, cost, term)))
+                Ok(vec![CommandOutput::ExtractBest(termdag, cost, term)])
             } else {
                 Err(Error::ExtractError(
                     "Unable to find any valid extraction (likely due to subsume or delete)"
@@ -269,7 +269,7 @@ impl UserDefinedCommand for CustomExtract {
                 .map(|e| e.1)
                 .collect();
             log::info!("extracted variants:");
-            Ok(Some(CommandOutput::ExtractVariants(termdag, terms)))
+            Ok(vec![CommandOutput::ExtractVariants(termdag, terms)])
         }
     }
 }

--- a/src/set_cost.rs
+++ b/src/set_cost.rs
@@ -1,13 +1,13 @@
 use egglog_ast::span::Span;
+use log::log_enabled;
 use std::sync::Arc;
 
 use egglog::{
-    CommandOutput, EGraph, Error, TermDag, TermId, TypeError, UserDefinedCommand,
+    CommandOutput, EGraph, TermDag, TermId, UserDefinedCommand,
     ast::*,
     extract::{CostModel, DefaultCost, Extractor, TreeAdditiveCostModel},
     util::FreshGen,
 };
-use log::log_enabled;
 
 pub fn add_set_cost(egraph: &mut EGraph) {
     egraph
@@ -222,54 +222,58 @@ impl UserDefinedCommand for CustomExtract {
         egraph: &mut EGraph,
         args: &[Expr],
     ) -> Result<Vec<CommandOutput>, egglog::Error> {
-        assert!(args.len() <= 2);
-        let (sort, value) = egraph.eval_expr(&args[0])?;
-        let n = args.get(1).map(|arg| egraph.eval_expr(arg)).transpose()?;
-        let n = if let Some(nv) = n {
-            // TODO: egglog does not yet support u64
-            if nv.0.name() != "i64" {
+        extract_with_cost_model(egraph, args, DynamicCostModel)
+    }
+}
+
+/// Run an `(extract expr)` or `(extract expr n)` using the given cost model.
+/// Parses args, evaluates n if present, and dispatches to extract-best or extract-variants.
+pub(crate) fn extract_with_cost_model<CM>(
+    egraph: &mut egglog::EGraph,
+    args: &[Expr],
+    cost_model: CM,
+) -> Result<Vec<CommandOutput>, egglog::Error>
+where
+    CM: CostModel<DefaultCost> + Clone + 'static,
+{
+    let (expr, variants) = match args {
+        [expr] => (expr, 0usize),
+        [expr, n_expr] => {
+            let (n_sort, n_val) = egraph.eval_expr(n_expr)?;
+            if n_sort.name() != "i64" {
                 let i64sort = egraph.get_arcsort_by(|s| s.name() == "i64");
-                return Err(Error::TypeError(TypeError::Mismatch {
-                    expr: args[1].clone(),
+                return Err(egglog::Error::TypeError(egglog::TypeError::Mismatch {
+                    expr: n_expr.clone(),
                     expected: i64sort,
-                    actual: nv.0,
+                    actual: n_sort,
                 }));
             }
-            egraph.value_to_base::<i64>(nv.1)
-        } else {
-            0
-        };
-
-        let mut termdag = TermDag::default();
-
-        let extractor = Extractor::compute_costs_from_rootsorts(
-            Some(vec![sort.clone()]),
-            egraph,
-            DynamicCostModel,
-        );
-        if n == 0 {
-            if let Some((cost, term)) = extractor.extract_best(egraph, &mut termdag, value) {
-                if log_enabled!(log::Level::Info) {
-                    log::info!("extracted with cost {cost}: {}", termdag.to_string(term));
-                }
-                Ok(vec![CommandOutput::ExtractBest(termdag, cost, term)])
-            } else {
-                Err(Error::ExtractError(
-                    "Unable to find any valid extraction (likely due to subsume or delete)"
-                        .to_string(),
-                ))
-            }
-        } else {
-            if n < 0 {
-                panic!("Cannot extract negative number of variants");
-            }
-            let terms: Vec<TermId> = extractor
-                .extract_variants(egraph, &mut termdag, value, n as usize)
-                .iter()
-                .map(|e| e.1)
-                .collect();
-            log::info!("extracted variants:");
-            Ok(vec![CommandOutput::ExtractVariants(termdag, terms)])
+            let n = egraph.value_to_base::<i64>(n_val);
+            assert!(n >= 0, "Cannot extract negative number of variants");
+            (expr, n as usize)
         }
+        _ => panic!("extract takes 1 or 2 arguments"),
+    };
+    let (sort, value) = egraph.eval_expr(expr)?;
+    let extractor = Extractor::compute_costs_from_rootsorts(Some(vec![sort]), egraph, cost_model);
+    let mut termdag = TermDag::default();
+    if variants == 0 {
+        if let Some((cost, term)) = extractor.extract_best(egraph, &mut termdag, value) {
+            if log_enabled!(log::Level::Info) {
+                log::info!("extracted with cost {cost}: {}", termdag.to_string(term));
+            }
+            Ok(vec![CommandOutput::ExtractBest(termdag, cost, term)])
+        } else {
+            Err(egglog::Error::ExtractError(
+                "Unable to find any valid extraction (likely due to subsume or delete)".to_string(),
+            ))
+        }
+    } else {
+        let terms: Vec<TermId> = extractor
+            .extract_variants(egraph, &mut termdag, value, variants)
+            .iter()
+            .map(|e| e.1)
+            .collect();
+        Ok(vec![CommandOutput::ExtractVariants(termdag, terms)])
     }
 }

--- a/src/set_cost.rs
+++ b/src/set_cost.rs
@@ -1,7 +1,4 @@
-use egglog_ast::span::Span;
-use log::log_enabled;
-use std::sync::Arc;
-
+use crate::Error;
 use egglog::{
     CommandOutput, EGraph, TermDag, TermId, UserDefinedCommand,
     ast::*,
@@ -9,6 +6,9 @@ use egglog::{
     span,
     util::FreshGen,
 };
+use egglog_ast::span::Span;
+use log::log_enabled;
+use std::sync::Arc;
 
 pub fn add_set_cost(egraph: &mut EGraph) {
     egraph
@@ -245,9 +245,9 @@ impl UserDefinedCommand for CustomExtract {
             if nv.0.name() != "i64" {
                 let i64sort = egraph.get_arcsort_by(|s| s.name() == "i64");
                 return Err(egglog::Error::TypeError(egglog::TypeError::Mismatch {
-                    expr: n_expr.clone(),
+                    expr: args[1].clone(),
                     expected: i64sort,
-                    actual: n_sort,
+                    actual: nv.0,
                 }));
             }
             egraph.value_to_base::<i64>(nv.1)
@@ -282,7 +282,6 @@ impl UserDefinedCommand for CustomExtract {
                         .to_string(),
                 ))
             }
-            Ok(vec![CommandOutput::ExtractBest(termdag, cost, term)])
         } else {
             let terms: Vec<TermId> = extractor
                 .extract_variants(egraph, &mut termdag, value, n as usize)
@@ -292,12 +291,5 @@ impl UserDefinedCommand for CustomExtract {
             log::info!("extracted variants:");
             Ok(vec![CommandOutput::ExtractVariants(termdag, terms)])
         }
-    } else {
-        let terms: Vec<TermId> = extractor
-            .extract_variants(egraph, &mut termdag, value, variants)
-            .iter()
-            .map(|e| e.1)
-            .collect();
-        Ok(vec![CommandOutput::ExtractVariants(termdag, terms)])
     }
 }

--- a/src/table_stats.rs
+++ b/src/table_stats.rs
@@ -341,7 +341,7 @@ pub fn print_table_stats(egraph: &EGraph, sym: Option<&str>) -> Result<Vec<Table
 }
 
 impl UserDefinedCommand for PrintTableStatsCommand {
-    fn update(&self, egraph: &mut EGraph, args: &[Expr]) -> Result<Option<CommandOutput>, Error> {
+    fn update(&self, egraph: &mut EGraph, args: &[Expr]) -> Result<Vec<CommandOutput>, Error> {
         let name: Option<String> = match args {
             [] => None,
             [arg] => match arg {
@@ -361,8 +361,8 @@ impl UserDefinedCommand for PrintTableStatsCommand {
             }
         };
         let stats = print_table_stats(egraph, name.as_deref())?;
-        Ok(Some(CommandOutput::UserDefined(Arc::new(
+        Ok(vec![CommandOutput::UserDefined(Arc::new(
             TableStatsOutput { stats },
-        ))))
+        ))])
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -239,6 +239,83 @@ fn test_multi_extract_with_set_cost() {
     assert!(!output.contains("Mul"));
 }
 
+#[test]
+fn test_keep_best_basic() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (datatype Math (Num i64) (Add Math Math))
+        (relation Target (Math))
+
+        ; put two nodes in the same eclass
+        (union (Num 2) (Add (Num 1) (Num 1)))
+
+        ; record what we care about
+        (Target (Num 2))
+        "#,
+        )
+        .unwrap();
+
+    // Before keep-best: both Num and Add tables have entries, Target has 1 row.
+    assert_eq!(egraph.get_size("Num"), 2);
+    assert_eq!(egraph.get_size("Add"), 1);
+    assert_eq!(egraph.get_size("Target"), 1);
+
+    // Run keep-best on the Target relation.
+    egraph
+        .parse_and_run_program(None, r#"(keep-best "Target")"#)
+        .unwrap();
+
+    // After keep-best: Target still has exactly 1 row,
+    // and it contains a constructor term that can be extracted.
+    assert_eq!(egraph.get_size("Target"), 1);
+    assert_eq!(egraph.get_size("Num"), 1);
+
+    let result = egraph
+        .parse_and_run_program(None, "(print-function Target 100)")
+        .unwrap();
+    let output = result[0].to_string();
+    assert!(output.contains("Num") && !output.contains("Add"));
+}
+
+#[test]
+fn test_keep_best_clears_other_tables() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (datatype Math (Num i64) (Add Math Math))
+        (relation Target (Math))
+        (Num 42)
+        (Add (Num 1) (Num 2))
+        (Target (Num 42))
+        "#,
+        )
+        .unwrap();
+
+    let before_num = egraph.get_size("Num");
+    let before_add = egraph.get_size("Add");
+    assert!(before_num >= 3); // Num 42, Num 1, Num 2
+    assert_eq!(before_add, 1);
+    assert_eq!(egraph.get_size("Target"), 1);
+
+    egraph
+        .parse_and_run_program(None, r#"(keep-best "Target")"#)
+        .unwrap();
+
+    // After keep-best, Add table (not referenced by Target) should be empty.
+    // The Num table entry for 42 should be re-inserted (it's reachable via Target).
+    // Num 1 and Num 2 are not reachable from Target, so they should be gone.
+    assert_eq!(egraph.get_size("Add"), 0);
+    assert_eq!(egraph.get_size("Target"), 1);
+    assert_eq!(egraph.get_size("Num"), 1); // only Num 42 is kept
+}
+
 fn add_copy_backoff_program(egraph: &mut egglog::EGraph) {
     egraph
         .parse_and_run_program(
@@ -318,4 +395,62 @@ fn test_saturate_continues_until_scheduler_can_stop_after_no_progress_ban() {
         report.updated,
         "the eventual copy applications should be reported as database progress"
     );
+}
+
+#[test]
+fn test_schedule_call_prim() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (datatype Math (Num i64) (Add Math Math))
+        (relation Target (Math))
+        (union (Num 2) (Add (Num 1) (Num 1)))
+        (Target (Num 2))
+        "#,
+        )
+        .unwrap();
+
+    // call-prim inside a run-schedule: evaluate a primitive expression
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (run-schedule
+          (call-prim (get-size!)))
+        "#,
+        )
+        .unwrap();
+}
+
+#[test]
+fn test_schedule_user_defined_command() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (datatype Math (Num i64) (Add Math Math))
+        (relation Target (Math))
+        (union (Num 2) (Add (Num 1) (Num 1)))
+        (Target (Num 2))
+        "#,
+        )
+        .unwrap();
+
+    // keep-best as a step inside run-schedule
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (run-schedule
+          (keep-best "Target"))
+        "#,
+        )
+        .unwrap();
+
+    assert_eq!(egraph.get_size("Target"), 1);
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -398,7 +398,7 @@ fn test_saturate_continues_until_scheduler_can_stop_after_no_progress_ban() {
 }
 
 #[test]
-fn test_schedule_call_prim() {
+fn test_schedule_expr_eval() {
     let mut egraph = egglog_experimental::new_experimental_egraph();
 
     egraph
@@ -413,13 +413,13 @@ fn test_schedule_call_prim() {
         )
         .unwrap();
 
-    // call-prim inside a run-schedule: evaluate a primitive expression
+    // Direct expression evaluation as a schedule step (supersedes call-prim)
     egraph
         .parse_and_run_program(
             None,
             r#"
         (run-schedule
-          (call-prim (get-size!)))
+          (get-size!))
         "#,
         )
         .unwrap();
@@ -453,4 +453,168 @@ fn test_schedule_user_defined_command() {
         .unwrap();
 
     assert_eq!(egraph.get_size("Target"), 1);
+}
+
+#[test]
+fn test_schedule_repeat_push_pop_print_size() {
+    use egglog::CommandOutput;
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    // Commutativity and both directions of associativity for Add.
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (datatype Math (Num i64) (Add Math Math))
+        (ruleset math-rules)
+        (rewrite (Add a b) (Add b a) :ruleset math-rules)
+        (rewrite (Add (Add a b) c) (Add a (Add b c)) :ruleset math-rules)
+        (rewrite (Add a (Add b c)) (Add (Add a b) c) :ruleset math-rules)
+        "#,
+        )
+        .unwrap();
+
+    // Each of 3 outer iterations:
+    //   1. push the current (fact-free) state
+    //   2. insert a sum-1-to-5 addition chain as a schedule action
+    //   3. repeat 5 times: run math-rules one step, then print-size
+    //   4. pop back to the fact-free state
+    //
+    // print-size fires inside the inner repeat, so each outer iteration
+    // emits 5 PrintAllFunctionsSize outputs — 15 total.
+    let outputs = egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (run-schedule
+          (repeat 3
+            (push)
+            (Add (Add (Add (Add (Num 1) (Num 2)) (Num 3)) (Num 4)) (Num 5))
+            (repeat 5
+              (run math-rules)
+              (print-size))
+            (pop)))
+        "#,
+        )
+        .unwrap();
+
+    // 3 outer iterations × 5 inner steps = 15 PrintAllFunctionsSize outputs,
+    // followed by a single RunSchedule.
+    let print_size_outputs: Vec<_> = outputs
+        .iter()
+        .filter(|o| matches!(o, CommandOutput::PrintAllFunctionsSize(_)))
+        .collect();
+    assert_eq!(
+        print_size_outputs.len(),
+        15,
+        "expected 3 × 5 = 15 print-size outputs, got {}",
+        print_size_outputs.len()
+    );
+
+    let add_sizes: Vec<usize> = print_size_outputs
+        .into_iter()
+        .map(|o| match o {
+            CommandOutput::PrintAllFunctionsSize(v) => {
+                let add = v.iter().find(|(n, _)| n == "Add").map(|(_, s)| *s).unwrap();
+                let num = v.iter().find(|(n, _)| n == "Num").map(|(_, s)| *s).unwrap();
+                // Num is always 5 (one per distinct literal, shared via e-class).
+                assert_eq!(num, 5, "Num size should stay at 5");
+                add
+            }
+            _ => unreachable!(),
+        })
+        .collect();
+
+    // Expected Add sizes after each of the 5 rule steps, measured within a
+    // single outer iteration (the push/pop makes all three groups identical).
+    let expected = [14, 50, 137, 182, 180];
+    for group in 0..3 {
+        for step in 0..5 {
+            assert_eq!(
+                add_sizes[group * 5 + step],
+                expected[step],
+                "outer iteration {group}, inner step {step}: unexpected Add size"
+            );
+        }
+    }
+
+    // The last output is always the RunSchedule report.
+    assert!(
+        matches!(outputs.last().unwrap(), CommandOutput::RunSchedule(_)),
+        "last output must be RunSchedule"
+    );
+
+    // After the repeat the pop has unwound all facts — the e-graph is back to
+    // the state it had after defining the datatype (no concrete tuples).
+    assert_eq!(egraph.get_size("Add"), 0);
+    assert_eq!(egraph.get_size("Num"), 0);
+}
+
+#[test]
+fn test_schedule_commands_and_actions() {
+    use egglog::CommandOutput;
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (datatype Math (Num i64) (Add Math Math))
+        (relation Target (Math))
+        (union (Num 2) (Add (Num 1) (Num 1)))
+        (Target (Num 2))
+        "#,
+        )
+        .unwrap();
+
+    // print-size inside run-schedule returns a CommandOutput::PrintFunctionSize
+    let outputs = egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (run-schedule
+          (print-size Target))
+        "#,
+        )
+        .unwrap();
+
+    // outputs should be: [PrintFunctionSize(...), RunSchedule(report)]
+    assert!(outputs.len() >= 2, "expected at least 2 outputs, got {}", outputs.len());
+    assert!(matches!(outputs[0], CommandOutput::PrintFunctionSize(_)));
+    assert!(matches!(outputs.last().unwrap(), CommandOutput::RunSchedule(_)));
+
+    // extract inside run-schedule
+    let outputs = egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (run-schedule
+          (extract (Num 2) 0))
+        "#,
+        )
+        .unwrap();
+    assert!(outputs.iter().any(|o| matches!(o, CommandOutput::ExtractBest(..))));
+
+    // union as a schedule step
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (run-schedule
+          (union (Num 1) (Num 2)))
+        "#,
+        )
+        .unwrap();
+
+    // push/pop as schedule steps
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (run-schedule
+          (push)
+          (pop))
+        "#,
+        )
+        .unwrap();
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -314,6 +314,9 @@ fn test_keep_best_clears_other_tables() {
     assert_eq!(egraph.get_size("Add"), 0);
     assert_eq!(egraph.get_size("Target"), 1);
     assert_eq!(egraph.get_size("Num"), 1); // only Num 42 is kept
+}
+
+#[test]
 fn test_extract_missing_expression_returns_error_instead_of_panicking() {
     let mut egraph = egglog_experimental::new_experimental_egraph();
 
@@ -623,16 +626,36 @@ fn test_schedule_expr_eval() {
         )
         .unwrap();
 
-    // Direct expression evaluation as a schedule step (supersedes call-prim)
+    // `(eval <expr>)` evaluates an expression as a schedule step in the full
+    // read/write (FullState) context. Here it calls the `get-size!` reading
+    // primitive, which is only admissible because of that full context.
     egraph
         .parse_and_run_program(
             None,
             r#"
         (run-schedule
-          (get-size!))
+          (eval (get-size!)))
         "#,
         )
         .unwrap();
+
+    // `(eval <expr>)` also adds constructor terms to the e-graph, just like a
+    // top-level expression would.
+    let before = egraph.get_size("Add");
+    egraph
+              .parse_and_run_program(
+                  None,
+                  r#"                                                                                      
+              (run-schedule                                                                                
+                (eval (Add (Num 3) (Num 4))))                                                              
+              "#,
+              )
+              .unwrap();
+    assert_eq!(
+        egraph.get_size("Add"),
+        before + 1,
+        "(eval ...) should add the new Add term to the e-graph"
+    );
 }
 
 #[test]
@@ -686,7 +709,7 @@ fn test_schedule_repeat_push_pop_print_size() {
 
     // Each of 3 outer iterations:
     //   1. push the current (fact-free) state
-    //   2. insert a sum-1-to-5 addition chain as a schedule action
+    //   2. eval a sum-1-to-5 addition chain to add it to the e-graph
     //   3. repeat 5 times: run math-rules one step, then print-size
     //   4. pop back to the fact-free state
     //
@@ -699,7 +722,7 @@ fn test_schedule_repeat_push_pop_print_size() {
         (run-schedule
           (repeat 3
             (push)
-            (Add (Add (Add (Add (Num 1) (Num 2)) (Num 3)) (Num 4)) (Num 5))
+            (eval (Add (Add (Add (Add (Num 1) (Num 2)) (Num 3)) (Num 4)) (Num 5)))
             (repeat 5
               (run math-rules)
               (print-size))

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -579,9 +579,16 @@ fn test_schedule_commands_and_actions() {
         .unwrap();
 
     // outputs should be: [PrintFunctionSize(...), RunSchedule(report)]
-    assert!(outputs.len() >= 2, "expected at least 2 outputs, got {}", outputs.len());
+    assert!(
+        outputs.len() >= 2,
+        "expected at least 2 outputs, got {}",
+        outputs.len()
+    );
     assert!(matches!(outputs[0], CommandOutput::PrintFunctionSize(_)));
-    assert!(matches!(outputs.last().unwrap(), CommandOutput::RunSchedule(_)));
+    assert!(matches!(
+        outputs.last().unwrap(),
+        CommandOutput::RunSchedule(_)
+    ));
 
     // extract inside run-schedule
     let outputs = egraph
@@ -593,7 +600,11 @@ fn test_schedule_commands_and_actions() {
         "#,
         )
         .unwrap();
-    assert!(outputs.iter().any(|o| matches!(o, CommandOutput::ExtractBest(..))));
+    assert!(
+        outputs
+            .iter()
+            .any(|o| matches!(o, CommandOutput::ExtractBest(..)))
+    );
 
     // union as a schedule step
     egraph


### PR DESCRIPTION
Relies on https://github.com/egraphs-good/egglog/pull/895

This exposes a user-defined command called keep-best, which prunes the databases and keeps only the terms in the tables that are passed as arguments to `keep-best`.

Additionally, it also allows calling primitives and user-defined commands in the scheduling language.