### PR TITLE
ci: add a latest-dependencies build guard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,19 @@ jobs:
         tool: nextest
     - uses: Swatinem/rust-cache@v2
     - run: make test
+  # Downstreams install this crate with `cargo install`, which ignores the
+  # committed Cargo.lock and re-resolves every dependency to the latest
+  # compatible version. Reproduce that here so upstream dependency drift is
+  # caught in this repo instead of in downstream projects (e.g. Herbie).
+  # `cargo update` refreshes the lock to latest; the build then uses it.
+  latest-deps:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
+    - uses: actions/checkout@v3
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo update
+    - run: cargo build --release --all-targets
   nits:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Why

Downstream projects install this crate with `cargo install` (e.g. Herbie: `cargo install --git … egglog-experimental`). **`cargo install` ignores the committed `Cargo.lock` unless `--locked` is passed**, so it re-resolves the whole tree to the newest compatible versions. That means a breaking change in a transitive dependency can break downstream installs while our own CI — which uses the committed lock — stays green.

This just happened: `clap_derive` 4.6 moved to `syn 3.x`, which removed the `syn/full` feature that egglog's `add_primitive` proc macro was getting via feature unification. Herbie's `cargo install` broke; our CI did not notice.

## Change

Add a `latest-deps` job that runs `cargo update` and then builds, reproducing the lock-ignoring resolution downstreams get. This surfaces upstream dependency drift here, close to the source, instead of in downstream repos.

Pairs with the egglog fix (`add_primitive` declaring `syn`'s `full` feature). Note: a latest-deps job can go red on unrelated upstream releases; if that's noisy, it can be moved to a `schedule:` trigger and/or marked non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)