### PR TITLE
Bump egglog to fix `cargo install`, and migrate to the name-indexed Read/Write API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd#5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=53b9721b9706741edff2b7c1e379fc37137184d9#53b9721b9706741edff2b7c1e379fc37137184d9"
 dependencies = [
  "chrono",
  "clap",
@@ -352,9 +352,9 @@ dependencies = [
  "mimalloc",
  "num",
  "ordered-float",
- "rayon",
  "rustc-hash",
  "serde_json",
+ "smallvec",
  "thiserror",
  "web-time",
 ]
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd#5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=53b9721b9706741edff2b7c1e379fc37137184d9#53b9721b9706741edff2b7c1e379fc37137184d9"
 dependencies = [
  "quote",
  "syn 2.0.108",
@@ -371,7 +371,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd#5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=53b9721b9706741edff2b7c1e379fc37137184d9#53b9721b9706741edff2b7c1e379fc37137184d9"
 dependencies = [
  "ordered-float",
 ]
@@ -379,10 +379,11 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd#5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=53b9721b9706741edff2b7c1e379fc37137184d9#53b9721b9706741edff2b7c1e379fc37137184d9"
 dependencies = [
  "anyhow",
  "dyn-clone",
+ "egglog-concurrency",
  "egglog-core-relations",
  "egglog-numeric-id",
  "egglog-reports",
@@ -393,7 +394,6 @@ dependencies = [
  "num-rational",
  "once_cell",
  "ordered-float",
- "rayon",
  "smallvec",
  "thiserror",
  "web-time",
@@ -402,19 +402,19 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd#5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=53b9721b9706741edff2b7c1e379fc37137184d9#53b9721b9706741edff2b7c1e379fc37137184d9"
 dependencies = [
  "arc-swap",
  "bumpalo",
+ "crossbeam",
  "egglog-numeric-id",
- "rayon",
  "smallvec",
 ]
 
 [[package]]
 name = "egglog-core-relations"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd#5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=53b9721b9706741edff2b7c1e379fc37137184d9#53b9721b9706741edff2b7c1e379fc37137184d9"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -433,7 +433,6 @@ dependencies = [
  "num",
  "once_cell",
  "rand 0.9.2",
- "rayon",
  "rustc-hash",
  "smallvec",
  "thiserror",
@@ -457,15 +456,12 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd#5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd"
-dependencies = [
- "rayon",
-]
+source = "git+https://github.com/egraphs-good/egglog.git?rev=53b9721b9706741edff2b7c1e379fc37137184d9#53b9721b9706741edff2b7c1e379fc37137184d9"
 
 [[package]]
 name = "egglog-reports"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd#5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=53b9721b9706741edff2b7c1e379fc37137184d9#53b9721b9706741edff2b7c1e379fc37137184d9"
 dependencies = [
  "clap",
  "hashbrown 0.16.0",
@@ -479,7 +475,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd#5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=53b9721b9706741edff2b7c1e379fc37137184d9#53b9721b9706741edff2b7c1e379fc37137184d9"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",
@@ -499,12 +495,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "enum-map"
@@ -1082,26 +1072,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { git = "https://github.com/egraphs-good/egglog.git", rev = "5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd", default-features = false }
-egglog-ast = { git = "https://github.com/egraphs-good/egglog.git", rev = "5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd", default-features = false }
-egglog-reports = { git = "https://github.com/egraphs-good/egglog.git", rev = "5294cdc66a7b90a9a1480cb2d930f2ee5785c8dd", default-features = false }
+egglog = { git = "https://github.com/egraphs-good/egglog.git", rev = "53b9721b9706741edff2b7c1e379fc37137184d9", default-features = false }
+egglog-ast = { git = "https://github.com/egraphs-good/egglog.git", rev = "53b9721b9706741edff2b7c1e379fc37137184d9", default-features = false }
+egglog-reports = { git = "https://github.com/egraphs-good/egglog.git", rev = "53b9721b9706741edff2b7c1e379fc37137184d9", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/src/keep_best.rs
+++ b/src/keep_best.rs
@@ -7,8 +7,10 @@
 //!
 //! Each argument must evaluate to a `String` that names an existing function.
 
+use crate::table_rows::{for_each_row, is_constructor};
 use egglog::{
-    ArcSort, CommandOutput, EGraph, Error, TermDag, TermId, TypeError, UserDefinedCommand, Value,
+    ArcSort, CommandOutput, EGraph, Error, RawValues, TermDag, TermId, TypeError,
+    UserDefinedCommand, Value, Write,
     ast::Expr,
     extract::{Extractor, TreeAdditiveCostModel},
     sort::S,
@@ -45,20 +47,33 @@ impl UserDefinedCommand for KeepBestCommand {
 
         // Step 4: re-insert the optimal tuples. Evaluate each extracted term
         // via eval_expr so that constructor sub-terms are re-created bottom-up,
-        // then stage all target-table inserts in one with_full_state call.
-        let mut rows_to_insert: Vec<(String, Vec<Value>)> = Vec::new();
+        // then stage all target-table inserts in one `update` call.
+        let mut rows_to_insert: Vec<(String, bool, Vec<Value>)> = Vec::new();
         for (table_name, extracted_rows, termdag) in &extracted {
+            let constructor = is_constructor(egraph, table_name)?;
             for term_ids in extracted_rows {
                 let values = eval_terms(egraph, termdag, term_ids)?;
-                rows_to_insert.push((table_name.clone(), values));
+                rows_to_insert.push((table_name.clone(), constructor, values));
             }
         }
 
-        egraph.with_full_state(|mut state| {
-            for (table_name, values) in &rows_to_insert {
-                egglog::Write::insert(&mut state, table_name, values.iter().copied());
+        egraph.update(|mut state| {
+            for (table_name, constructor, values) in &rows_to_insert {
+                let (output, inputs) = values
+                    .split_last()
+                    .expect("extracted row has at least an output column");
+                if *constructor {
+                    // `add` mints (or finds) the eclass for these inputs; the
+                    // union pins it to the eclass the extracted output term
+                    // evaluated to, which is what the raw row insert used to do.
+                    let eclass = state.add(table_name, RawValues(inputs.to_vec()))?;
+                    state.union(eclass, *output)?;
+                } else {
+                    state.set(table_name, RawValues(inputs.to_vec()), *output)?;
+                }
             }
-        });
+            Ok(())
+        })?;
 
         Ok(vec![])
     }
@@ -89,8 +104,8 @@ fn collect_and_extract(
             .collect();
 
         let mut raw_rows: Vec<Vec<Value>> = Vec::new();
-        egraph.function_for_each(table_name, |row| {
-            raw_rows.push(row.vals.to_vec());
+        for_each_row(egraph, table_name, |vals| {
+            raw_rows.push(vals.to_vec());
         })?;
 
         let extractor = Extractor::compute_costs_from_rootsorts(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ pub use multi_extract::*;
 mod size;
 pub use size::*;
 mod primitive;
+mod table_rows;
 mod table_stats;
 pub use table_stats::*;
 

--- a/src/set_cost.rs
+++ b/src/set_cost.rs
@@ -1,6 +1,6 @@
 use crate::Error;
 use egglog::{
-    CommandOutput, EGraph, TermDag, TermId, UserDefinedCommand,
+    CommandOutput, EGraph, RawValues, Read, TermDag, TermId, UserDefinedCommand,
     ast::*,
     extract::{CostModel, DefaultCost, Extractor, TreeAdditiveCostModel},
     span,
@@ -196,21 +196,22 @@ impl CostModel<DefaultCost> for DynamicCostModel {
         &self,
         egraph: &EGraph,
         func: &egglog::Function,
-        row: &egglog::FunctionRow<'_>,
+        enode: &egglog::Enode<'_>,
     ) -> DefaultCost {
         let name = get_cost_table_name(func.name());
-        let key = row.vals.split_last().unwrap().1;
         if egraph.get_function(&name).is_some() {
             egraph
-                .lookup_function(&name, key)
+                .read(|state| state.lookup(&name, RawValues(enode.children.to_vec())))
+                .ok()
+                .flatten()
                 .map(|c| {
                     let cost = egraph.value_to_base::<i64>(c);
                     assert!(cost >= 0);
                     cost as DefaultCost
                 })
-                .unwrap_or_else(|| TreeAdditiveCostModel {}.enode_cost(egraph, func, row))
+                .unwrap_or_else(|| TreeAdditiveCostModel {}.enode_cost(egraph, func, enode))
         } else {
-            TreeAdditiveCostModel {}.enode_cost(egraph, func, row)
+            TreeAdditiveCostModel {}.enode_cost(egraph, func, enode)
         }
     }
 }

--- a/src/sugar/for.rs
+++ b/src/sugar/for.rs
@@ -42,8 +42,9 @@ impl Macro<Vec<Command>> for For {
             body: query,
             name: rulename,
             ruleset: ruleset.clone(),
-            naive: false,
+            eval_mode: RuleEvalMode::Seminaive,
             no_decomp: false,
+            include_subsumed: false,
         };
 
         Ok(vec![

--- a/src/table_rows.rs
+++ b/src/table_rows.rs
@@ -1,0 +1,47 @@
+//! Subtype-agnostic row iteration over e-graph tables.
+//!
+//! egglog splits table scans by subtype: [`EGraph::function_entries`] for
+//! `function` tables and [`EGraph::constructor_enodes`] for constructors and
+//! relations. Several commands in this crate treat both uniformly, so this
+//! helper dispatches on the subtype and hands the callback the whole row —
+//! inputs followed by the output (or eclass) column.
+
+use egglog::{ApiError, EGraph, Error, Value};
+
+/// Call `f` once per row of `name`, with every column in schema order.
+pub(crate) fn for_each_row(
+    egraph: &EGraph,
+    name: &str,
+    mut f: impl FnMut(&[Value]),
+) -> Result<(), Error> {
+    let mut row: Vec<Value> = Vec::new();
+    if is_constructor(egraph, name)? {
+        egraph.constructor_enodes(name, |enode| {
+            row.clear();
+            row.extend_from_slice(enode.children);
+            row.push(enode.eclass);
+            f(&row);
+        })
+    } else {
+        egraph.function_entries(name, |entry| {
+            row.clear();
+            row.extend_from_slice(entry.inputs);
+            row.push(entry.output);
+            f(&row);
+        })
+    }
+}
+
+/// Whether `name` is a constructor (or relation) table rather than a
+/// `function` table.
+///
+/// egglog exposes no subtype accessor on [`egglog::Function`], so probe with a
+/// constructor scan that stops before reading a row and read the answer off the
+/// subtype check, which runs before any iteration.
+pub(crate) fn is_constructor(egraph: &EGraph, name: &str) -> Result<bool, Error> {
+    match egraph.constructor_enodes_while(name, |_| false) {
+        Ok(()) => Ok(true),
+        Err(Error::ApiError(ApiError::WrongSubtype { .. })) => Ok(false),
+        Err(err) => Err(err),
+    }
+}

--- a/src/table_stats.rs
+++ b/src/table_stats.rs
@@ -14,9 +14,9 @@
 //! (alphabetically). With one argument (an unquoted function name) only that
 //! function is reported.
 
+use crate::table_rows::for_each_row;
 use egglog::{
-    CommandOutput, EGraph, Error, FunctionRow, TypeError, UserDefinedCommand, Value, ast::Expr,
-    prelude::Span,
+    CommandOutput, EGraph, Error, TypeError, UserDefinedCommand, Value, ast::Expr, prelude::Span,
 };
 use egglog_ast::generic_ast::GenericExpr;
 use std::{
@@ -235,9 +235,8 @@ fn compute_table_stats(egraph: &EGraph, func_name: &str) -> Result<TableStats, E
     }
     let mut output_to_inputs_map: HashMap<Value, HashSet<Vec<Value>>> = HashMap::default();
 
-    egraph.function_for_each(func_name, |row: FunctionRow<'_>| {
+    for_each_row(egraph, func_name, |vals| {
         size += 1;
-        let vals = row.vals;
         debug_assert_eq!(vals.len(), n_cols);
         for (i, v) in vals.iter().enumerate() {
             distinct[i].insert(*v);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -436,6 +436,93 @@ fn test_keep_best_clears_other_tables() {
 }
 
 #[test]
+fn test_keep_best_function_table() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (datatype Math (Num i64) (Add Math Math))
+        (function Best (Math) i64 :no-merge)
+
+        ; two nodes in one eclass, so extraction has to pick the cheaper term
+        (union (Num 2) (Add (Num 1) (Num 1)))
+
+        (set (Best (Num 2)) 7)
+        "#,
+        )
+        .unwrap();
+
+    assert_eq!(egraph.get_size("Best"), 1);
+    assert_eq!(egraph.get_size("Add"), 1);
+
+    // A `function` table re-inserts via `set`, unlike the constructor and
+    // relation cases above, and carries a non-eq-sort output column.
+    egraph
+        .parse_and_run_program(None, r#"(keep-best "Best")"#)
+        .unwrap();
+
+    assert_eq!(egraph.get_size("Best"), 1);
+    assert_eq!(egraph.get_size("Add"), 0);
+
+    // The key comes back as the cheapest term for its eclass, and the output
+    // column survives the round trip.
+    let result = egraph
+        .parse_and_run_program(None, "(print-function Best 100)")
+        .unwrap();
+    let output = result[0].to_string();
+    assert!(output.contains("(Num 2)"), "unexpected output: {output}");
+    assert!(output.contains("7"), "unexpected output: {output}");
+    assert!(!output.contains("Add"), "unexpected output: {output}");
+}
+
+#[test]
+fn test_keep_best_mixed_function_and_relation() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (datatype Math (Num i64) (Add Math Math))
+        (relation Target (Math))
+        (function Best (Math) i64 :no-merge)
+
+        (union (Num 2) (Add (Num 1) (Num 1)))
+        (union (Num 3) (Add (Num 1) (Num 2)))
+
+        (Target (Num 3))
+        (set (Best (Num 2)) 7)
+        "#,
+        )
+        .unwrap();
+
+    // One keep-best call spanning both subtypes, so each table has to be
+    // dispatched independently on the way back in.
+    egraph
+        .parse_and_run_program(None, r#"(keep-best "Target" "Best")"#)
+        .unwrap();
+
+    assert_eq!(egraph.get_size("Target"), 1);
+    assert_eq!(egraph.get_size("Best"), 1);
+    assert_eq!(egraph.get_size("Add"), 0);
+
+    let target = egraph
+        .parse_and_run_program(None, "(print-function Target 100)")
+        .unwrap()[0]
+        .to_string();
+    assert!(target.contains("(Num 3)"), "unexpected output: {target}");
+
+    let best = egraph
+        .parse_and_run_program(None, "(print-function Best 100)")
+        .unwrap()[0]
+        .to_string();
+    assert!(best.contains("(Num 2)"), "unexpected output: {best}");
+    assert!(best.contains("7"), "unexpected output: {best}");
+}
+
+#[test]
 fn test_top_level_let_scheduler_persists_on_the_egraph() {
     let mut egraph = egglog_experimental::new_experimental_egraph();
 


### PR DESCRIPTION
## The problem

`cargo install` on this crate currently fails:

```
error: unsupported expression; enable syn's features=["full"]
  --> egglog/src/sort/bigrat.rs:96:13
error: proc macro panicked
  --> egglog/src/sort/bool.rs:15:9
```

egglog's `egglog-add-primitive` proc macro parses full Rust expressions through `syn::Expr`, but declared `syn` with default features only — which omit `full`. It built anyway because `clap_derive` (reached via `egglog/bin`) happened to enable `syn/full`, and Cargo unifies features across the proc-macro graph.

`clap_derive` 4.6.4 moved to **syn 3.0**, so nothing enables `full` on syn 2.x anymore and every `add_primitive!` body fails to parse.

Our `Cargo.lock` still pins `clap_derive` 4.5.x, so `cargo build` and CI were unaffected. But `cargo install` ignores the lockfile and re-resolves, which means the crate is currently uninstallable without `--locked` — and one `cargo update` away from breaking outright.

Upstream fixed this in egraphs-good/egglog#961 by declaring the feature directly. That commit sits at main's tip, so there's no narrower rev to land on: this bumps the three pins from `5294cdc` to `53b9721`.

## What the bump required

118 upstream commits, which broke 8 call sites across 4 files. Second commit migrates them:

- `GenericRule`'s `naive: bool` collapsed into `eval_mode: RuleEvalMode`, plus a new `include_subsumed` field.
- `FunctionRow`, `function_for_each`, `lookup_function`, `with_full_state` and `Write::insert` are gone, replaced by the name-indexed Read/Write surface (egglog#745, #751). Table scans now split by subtype, so `table_stats` and `keep_best` — which both scan uniformly — go through a new `table_rows` helper.
- `CostModel::enode_cost` takes `&Enode` instead of `&FunctionRow`.

## Two things worth a reviewer's attention

**`keep_best` constructor re-insert.** Constructors no longer have a raw whole-row insert, so this uses `add(table, inputs)` and unions the returned eclass with the value the extracted output term evaluated to. I believe that reproduces what forcing a raw row into an eclass did before, but it's a semantic reconstruction rather than a mechanical rename, so it deserves a real look.

**`is_constructor` is a workaround.** `Function` exposes no subtype accessor, so `table_rows` detects the subtype by probing and reading `ApiError::WrongSubtype`. The check runs before any iteration, so it's cheap and can't half-consume a table — but a `Function::subtype()` upstream would let this collapse to a field read. Happy to send that separately if it'd be welcome.

**Also note:** `EGraph::update` refuses to run when proofs are enabled, which `with_full_state` did not. `keep-best` now errors in proof mode instead of silently producing derivations the proof encoding can't check. Nothing here combines the two today.

## Testing

- `cargo install --path .` now succeeds without `--locked`.
- Full suite green: 39 `.egg` file tests, 41 integration tests, 8 fresh tests, 0 failures.
- `cargo clippy --all-targets`: no warnings.
- Third commit adds coverage for `keep-best` on function tables — both existing tests use a relation, so the `set` re-insert branch and `function_entries` scan (exactly what this PR rewrote) had none. Verified non-vacuous: forcing the constructor branch unconditionally fails both new tests while the two existing ones still pass.

The honest caveat: 118 commits carries real upstream behavior along with it — relations desugaring to constructors, Rayon replaced by egglog's own thread pool, proof-encoding and scheduler changes. The suite passing is the evidence available, not proof that nothing subtle shifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)