### PR TITLE
Prepare egglog-experimental 3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file records notable user-facing changes to egglog-experimental.
 
 ## [Unreleased]
 
-## [3.0.0] - 2026-08-19
+## [3.0.0] - 2026-08-20
 
 This is the first crates.io release of egglog-experimental. Its major version
 matches egglog 3, with which it is compatible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+This file records notable user-facing changes to egglog-experimental.
+
+## [Unreleased]
+
+## [3.0.0] - 2026-08-19
+
+This is the first crates.io release of egglog-experimental. Its major version
+matches egglog 3, with which it is compatible.
+
+### Added
+
+- An extended scheduling language with named back-off schedulers, sequencing,
+  saturation, repetition, full-context expression evaluation, and command steps.
+- Dynamic extraction costs, multi-term/multi-variant extraction, and `keep-best`
+  compaction.
+- Body-defined primitives, one-shot `for` rules, grouped `with-ruleset`
+  declarations, and fresh values in rule actions.
+- Exact rational values and their arithmetic, comparison, rounding, partial
+  power/root, and conversion primitives.
+- E-graph table-size queries and per-table column and out-degree statistics.
+- The `egglog-experimental` command-line program and
+  `new_experimental_egraph` Rust entry point.
+
+[Unreleased]: https://github.com/egraphs-good/egglog-experimental/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/egraphs-good/egglog-experimental/tree/v3.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "egglog-experimental"
-version = "1.0.0"
+version = "3.0.0"
 dependencies = [
  "egglog",
  "egglog-ast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -19,9 +19,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -34,62 +34,71 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
-version = "1.7.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitmaps"
@@ -101,25 +110,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cc"
-version = "1.2.43"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739eb0f94557554b3ca9a86d2d37bebd49c5e6d0c1d2bda35ba5bdac830befc2"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -133,18 +133,18 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.50"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2cfd7bf8a6017ddaa4e32ffe7403d547790db06bd171c1c53926faab501623"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.50"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4c05b9e80c5ccd3a7ef080ad7b6ba7d6fc00a985b8b157197075677c82c7a0"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -164,36 +164,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "crossbeam"
@@ -210,18 +201,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -229,37 +220,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "csv"
@@ -284,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -297,13 +278,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.7"
+name = "defmt"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -329,8 +331,8 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "egglog"
-version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=53b9721b9706741edff2b7c1e379fc37137184d9#53b9721b9706741edff2b7c1e379fc37137184d9"
+version = "3.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=8879605cafad303db25787406163a7e5bc845f5d#8879605cafad303db25787406163a7e5bc845f5d"
 dependencies = [
  "chrono",
  "clap",
@@ -345,7 +347,7 @@ dependencies = [
  "egraph-serialize",
  "enum-map",
  "env_logger",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "im-rc",
  "indexmap",
  "log",
@@ -361,25 +363,25 @@ dependencies = [
 
 [[package]]
 name = "egglog-add-primitive"
-version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=53b9721b9706741edff2b7c1e379fc37137184d9#53b9721b9706741edff2b7c1e379fc37137184d9"
+version = "3.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=8879605cafad303db25787406163a7e5bc845f5d#8879605cafad303db25787406163a7e5bc845f5d"
 dependencies = [
  "quote",
- "syn 2.0.108",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "egglog-ast"
-version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=53b9721b9706741edff2b7c1e379fc37137184d9#53b9721b9706741edff2b7c1e379fc37137184d9"
+version = "3.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=8879605cafad303db25787406163a7e5bc845f5d#8879605cafad303db25787406163a7e5bc845f5d"
 dependencies = [
  "ordered-float",
 ]
 
 [[package]]
 name = "egglog-bridge"
-version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=53b9721b9706741edff2b7c1e379fc37137184d9#53b9721b9706741edff2b7c1e379fc37137184d9"
+version = "3.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=8879605cafad303db25787406163a7e5bc845f5d#8879605cafad303db25787406163a7e5bc845f5d"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -388,7 +390,7 @@ dependencies = [
  "egglog-numeric-id",
  "egglog-reports",
  "egglog-union-find",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "indexmap",
  "log",
  "num-rational",
@@ -401,8 +403,8 @@ dependencies = [
 
 [[package]]
 name = "egglog-concurrency"
-version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=53b9721b9706741edff2b7c1e379fc37137184d9#53b9721b9706741edff2b7c1e379fc37137184d9"
+version = "3.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=8879605cafad303db25787406163a7e5bc845f5d#8879605cafad303db25787406163a7e5bc845f5d"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -413,8 +415,8 @@ dependencies = [
 
 [[package]]
 name = "egglog-core-relations"
-version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=53b9721b9706741edff2b7c1e379fc37137184d9#53b9721b9706741edff2b7c1e379fc37137184d9"
+version = "3.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=8879605cafad303db25787406163a7e5bc845f5d#8879605cafad303db25787406163a7e5bc845f5d"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -427,12 +429,12 @@ dependencies = [
  "egglog-reports",
  "egglog-union-find",
  "fixedbitset",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "indexmap",
  "log",
  "num",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rustc-hash",
  "smallvec",
  "thiserror",
@@ -441,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "egglog-experimental"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "egglog",
  "egglog-ast",
@@ -455,16 +457,16 @@ dependencies = [
 
 [[package]]
 name = "egglog-numeric-id"
-version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=53b9721b9706741edff2b7c1e379fc37137184d9#53b9721b9706741edff2b7c1e379fc37137184d9"
+version = "3.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=8879605cafad303db25787406163a7e5bc845f5d#8879605cafad303db25787406163a7e5bc845f5d"
 
 [[package]]
 name = "egglog-reports"
-version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=53b9721b9706741edff2b7c1e379fc37137184d9#53b9721b9706741edff2b7c1e379fc37137184d9"
+version = "3.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=8879605cafad303db25787406163a7e5bc845f5d#8879605cafad303db25787406163a7e5bc845f5d"
 dependencies = [
  "clap",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "indexmap",
  "rustc-hash",
  "serde",
@@ -474,8 +476,8 @@ dependencies = [
 
 [[package]]
 name = "egglog-union-find"
-version = "2.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=53b9721b9706741edff2b7c1e379fc37137184d9#53b9721b9706741edff2b7c1e379fc37137184d9"
+version = "3.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=8879605cafad303db25787406163a7e5bc845f5d#8879605cafad303db25787406163a7e5bc845f5d"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",
@@ -513,14 +515,14 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "env_filter"
-version = "0.1.4"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -528,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.8"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -552,7 +554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -563,15 +565,15 @@ checksum = "5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fixedbitset"
@@ -586,13 +588,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "generic-array"
-version = "0.14.9"
+name = "futures-core"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
- "typenum",
- "version_check",
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -603,21 +619,32 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
+name = "getrandom"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "graphviz-rust"
-version = "0.9.6"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db134cb611668917cabf340af9a39518426f9a10827b4cedcb4cdcf84443f6d0"
+checksum = "dee83cefff83c5dd5f34c603145f4e8d478e70cc17873049b6a36eeaf37b250a"
 dependencies = [
  "dot-generator",
  "dot-structures",
@@ -625,7 +652,7 @@ dependencies = [
  "into-attr-derive",
  "pest",
  "pest_derive",
- "rand 0.9.2",
+ "rand 0.9.5",
  "tempfile",
 ]
 
@@ -637,15 +664,22 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
  "serde",
+ "serde_core",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -669,12 +703,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -709,41 +743,54 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.15"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
+ "defmt",
+ "jiff-core",
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.15"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.81"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -755,25 +802,24 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.44"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
 dependencies = [
  "cc",
- "libc",
 ]
 
 [[package]]
 name = "libtest-mimic"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5297962ef19edda4ce33aaa484386e0a5b3d7f2f4e037cbeee00503ef6b29d33"
+checksum = "14e6ba06f0ade6e504aff834d7c34298e5155c6baca353cc6a4aaff2f9fd7f33"
 dependencies = [
  "anstream",
  "anstyle",
@@ -783,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -798,21 +844,21 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mimalloc"
-version = "0.1.48"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -833,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -852,20 +898,19 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -892,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -904,12 +949,12 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ordered-float"
-version = "5.1.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
 ]
 
@@ -928,9 +973,9 @@ dependencies = [
 
 [[package]]
 name = "pest"
-version = "2.8.3"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e7521a040efde50c3ab6bbadafbe15ab6dc042686926be59ac35d74607df4"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -938,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.3"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187da9a3030dbafabbbfb20cb323b976dc7b7ce91fcd84f2f74d6e31d378e2de"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -948,38 +993,43 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.3"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b401d98f5757ebe97a26085998d6c0eecec4995cad6ab7fc30ffdf4b052843"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.3"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f27a2cfee9f9039c4d86faa5af122a0ac3851441a34865b8a043b46be0065a"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
- "sha2",
 ]
 
 [[package]]
-name = "portable-atomic"
-version = "1.11.1"
+name = "pin-project-lite"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -995,18 +1045,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1018,10 +1068,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "rand_core 0.6.4",
  "serde",
@@ -1029,12 +1085,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1044,7 +1100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1058,11 +1114,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1080,14 +1136,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1097,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1108,40 +1164,40 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scopeguard"
@@ -1151,9 +1207,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1161,54 +1217,43 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap",
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
+ "zmij",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sized-chunks"
@@ -1221,10 +1266,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.15.1"
+name = "slab"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "strsim"
@@ -1245,9 +1296,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.108"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1256,42 +1318,42 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -1301,9 +1363,9 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.20"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "utf8parse"
@@ -1319,18 +1381,18 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.104"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1340,24 +1402,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.108",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.104"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1365,22 +1413,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.104"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
- "wasm-bindgen-backend",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.104"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -1403,15 +1451,6 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -1420,92 +1459,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.119",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egglog-experimental"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 description = "Experimental extensions to the egglog language."
 repository = "https://github.com/egraphs-good/egglog-experimental"
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { git = "https://github.com/egraphs-good/egglog.git", rev = "53b9721b9706741edff2b7c1e379fc37137184d9", default-features = false }
-egglog-ast = { git = "https://github.com/egraphs-good/egglog.git", rev = "53b9721b9706741edff2b7c1e379fc37137184d9", default-features = false }
-egglog-reports = { git = "https://github.com/egraphs-good/egglog.git", rev = "53b9721b9706741edff2b7c1e379fc37137184d9", default-features = false }
+egglog = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "8879605cafad303db25787406163a7e5bc845f5d", default-features = false }
+egglog-ast = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "8879605cafad303db25787406163a7e5bc845f5d", default-features = false }
+egglog-reports = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "8879605cafad303db25787406163a7e5bc845f5d", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egglog-experimental"
-version = "1.0.0"
+version = "3.0.0"
 edition = "2024"
 description = "Experimental extensions to the egglog language."
 repository = "https://github.com/egraphs-good/egglog-experimental"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cargo install --path=egglog-experimental
 To use it in a Rust project, you can add it as a dependency in a `Cargo.toml` file.
 
 ```
-egglog-experimental = "1.0"
+egglog-experimental = "3.0"
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -1,28 +1,66 @@
 # egglog-experimental
 
-This repo implements several experimental extensions to the core [`egglog`](https://github.com/egraphs-good/egglog).
-Currently, this can be thought of as a standard library to `egglog`.
+Experimental extensions to the core [`egglog`](https://github.com/egraphs-good/egglog)
+language and runtime. The crate can be used as a standard library for egglog
+programs that want to try features before they move into core.
 
-You can use the egglog [Zulip](https://egraphs.zulipchat.com/#narrow/stream/375765-egglog) to ask questions and suggest improvements to this repo.
+Questions and feature ideas are welcome on the egglog
+[Zulip](https://egraphs.zulipchat.com/#narrow/stream/375765-egglog).
 
-## Trying it out
+## Try it
 
-The easiest way to try out `egglog-experimental` is to use the [web demo](https://egraphs-good.github.io/egglog-demo), which builds on top of latest egglog-experimental.
+The quickest option is the [web demo](https://egraphs-good.github.io/egglog-demo),
+which includes egglog-experimental. To install the command-line program locally:
 
-To install egglog-experimental binary locally, you need to install `cargo` and run
-
+```sh
+cargo install egglog-experimental
+egglog-experimental path/to/program.egg
 ```
-git clone git@github.com:egraphs-good/egglog-experimental.git
-cargo install --path=egglog-experimental
-```
 
-To use it in a Rust project, you can add it as a dependency in a `Cargo.toml` file.
+To use all extensions from Rust:
 
-```
+```toml
+[dependencies]
 egglog-experimental = "3.0"
 ```
 
-## Documentation
+```rust
+let mut egraph = egglog_experimental::new_experimental_egraph();
+egraph.parse_and_run_program(None, program)?;
+```
 
-Check out the crate documentation (built locally) for the current list of implemented extensions, API details, and demo links.
-Releases are coordinated with compatible releases of egglog.
+`new_experimental_egraph` registers every extension below. Releases use the
+same major version as the compatible egglog release.
+
+## Features
+
+### Language and values
+
+| Extension | Syntax and behavior |
+| --- | --- |
+| [Exact rationals](https://egraphs-good.github.io/egglog-demo/?example=rational) | `Rational` values are built with `(rational numerator denominator)` and support arithmetic, comparisons, rounding, partial power/root operations, and numeric conversions. |
+| [`for`](https://egraphs-good.github.io/egglog-demo/?example=for) | `(for (fact...) (action...))` runs a generated rule once, which is useful for applying an action to every current match. |
+| [`with-ruleset`](https://egraphs-good.github.io/egglog-demo/?example=with-ruleset) | `(with-ruleset name rule-or-rewrite...)` assigns a group of rules, rewrites, and birewrites to one ruleset. |
+| Body-defined primitives | `(primitive name (InputSort...) OutputSort body)` defines a primitive using positional arguments `_0`, `_1`, and so on. Bodies may call existing primitives, functions, and globals. |
+| Fresh values | `(unstable-fresh! Sort [:cost N] [:unextractable])` creates a fresh value in a rule action for each match. |
+
+### Scheduling and extraction
+
+| Extension | Syntax and behavior |
+| --- | --- |
+| [Extended schedules](https://egraphs-good.github.io/egglog-demo/?example=math-backoff) | `(run-schedule step...)` supports `run`, `seq`, `saturate`, `repeat`, `eval`, and commands. `(let-scheduler name (back-off ...))` and `(run-with name ruleset)` add reusable custom schedulers. See the [`scheduling` module](https://docs.rs/egglog-experimental/latest/egglog_experimental/scheduling/) for the complete grammar. |
+| [Dynamic extraction costs](https://egraphs-good.github.io/egglog-demo/?example=05-cost-model-and-extraction) | Wrap datatype or constructor declarations in `(with-dynamic-cost ...)`, then use `(set-cost (Constructor args...) cost)` to change the cost used by `extract` and `multi-extract`. |
+| [Multiple extraction](https://egraphs-good.github.io/egglog-demo/?example=multi-extract) | `(multi-extract n term...)` returns the `n` lowest-cost variants of every term using one extractor pass. |
+| Best-term compaction | `(keep-best "table"...)` extracts the best representation of every value in the named tables, clears the e-graph, and reinserts only those compacted tables. |
+
+### Inspection
+
+| Extension | Syntax and behavior |
+| --- | --- |
+| [Table size](https://github.com/egraphs-good/egglog-experimental/blob/main/tests/web-demo/get-size.egg) | `(get-size!)` returns the total number of tuples; `(get-size! "table"...)` sums only the named tables. It can be used in schedule guards. |
+| Table statistics | `(print-table-stats)` reports every visible function table; `(print-table-stats Table)` reports one. Output includes row counts, distinct values per column, and out-degree distributions. |
+
+See the [crate documentation](https://docs.rs/egglog-experimental) for Rust APIs
+and the [`tests/web-demo`](https://github.com/egraphs-good/egglog-experimental/tree/main/tests/web-demo)
+directory for runnable examples. User-facing changes are recorded in the
+[changelog](CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -1,66 +1,28 @@
 # egglog-experimental
 
-Experimental extensions to the core [`egglog`](https://github.com/egraphs-good/egglog)
-language and runtime. The crate can be used as a standard library for egglog
-programs that want to try features before they move into core.
+This repo implements several experimental extensions to the core [`egglog`](https://github.com/egraphs-good/egglog).
+Currently, this can be thought of as a standard library to `egglog`.
 
-Questions and feature ideas are welcome on the egglog
-[Zulip](https://egraphs.zulipchat.com/#narrow/stream/375765-egglog).
+You can use the egglog [Zulip](https://egraphs.zulipchat.com/#narrow/stream/375765-egglog) to ask questions and suggest improvements to this repo.
 
-## Try it
+## Trying it out
 
-The quickest option is the [web demo](https://egraphs-good.github.io/egglog-demo),
-which includes egglog-experimental. To install the command-line program locally:
+The easiest way to try out `egglog-experimental` is to use the [web demo](https://egraphs-good.github.io/egglog-demo), which builds on top of latest egglog-experimental.
 
-```sh
-cargo install egglog-experimental
-egglog-experimental path/to/program.egg
+To install egglog-experimental binary locally, you need to install `cargo` and run
+
+```
+git clone git@github.com:egraphs-good/egglog-experimental.git
+cargo install --path=egglog-experimental
 ```
 
-To use all extensions from Rust:
+To use it in a Rust project, you can add it as a dependency in a `Cargo.toml` file.
 
-```toml
-[dependencies]
+```
 egglog-experimental = "3.0"
 ```
 
-```rust
-let mut egraph = egglog_experimental::new_experimental_egraph();
-egraph.parse_and_run_program(None, program)?;
-```
+## Documentation
 
-`new_experimental_egraph` registers every extension below. Releases use the
-same major version as the compatible egglog release.
-
-## Features
-
-### Language and values
-
-| Extension | Syntax and behavior |
-| --- | --- |
-| [Exact rationals](https://egraphs-good.github.io/egglog-demo/?example=rational) | `Rational` values are built with `(rational numerator denominator)` and support arithmetic, comparisons, rounding, partial power/root operations, and numeric conversions. |
-| [`for`](https://egraphs-good.github.io/egglog-demo/?example=for) | `(for (fact...) (action...))` runs a generated rule once, which is useful for applying an action to every current match. |
-| [`with-ruleset`](https://egraphs-good.github.io/egglog-demo/?example=with-ruleset) | `(with-ruleset name rule-or-rewrite...)` assigns a group of rules, rewrites, and birewrites to one ruleset. |
-| Body-defined primitives | `(primitive name (InputSort...) OutputSort body)` defines a primitive using positional arguments `_0`, `_1`, and so on. Bodies may call existing primitives, functions, and globals. |
-| Fresh values | `(unstable-fresh! Sort [:cost N] [:unextractable])` creates a fresh value in a rule action for each match. |
-
-### Scheduling and extraction
-
-| Extension | Syntax and behavior |
-| --- | --- |
-| [Extended schedules](https://egraphs-good.github.io/egglog-demo/?example=math-backoff) | `(run-schedule step...)` supports `run`, `seq`, `saturate`, `repeat`, `eval`, and commands. `(let-scheduler name (back-off ...))` and `(run-with name ruleset)` add reusable custom schedulers. See the [`scheduling` module](https://docs.rs/egglog-experimental/latest/egglog_experimental/scheduling/) for the complete grammar. |
-| [Dynamic extraction costs](https://egraphs-good.github.io/egglog-demo/?example=05-cost-model-and-extraction) | Wrap datatype or constructor declarations in `(with-dynamic-cost ...)`, then use `(set-cost (Constructor args...) cost)` to change the cost used by `extract` and `multi-extract`. |
-| [Multiple extraction](https://egraphs-good.github.io/egglog-demo/?example=multi-extract) | `(multi-extract n term...)` returns the `n` lowest-cost variants of every term using one extractor pass. |
-| Best-term compaction | `(keep-best "table"...)` extracts the best representation of every value in the named tables, clears the e-graph, and reinserts only those compacted tables. |
-
-### Inspection
-
-| Extension | Syntax and behavior |
-| --- | --- |
-| [Table size](https://github.com/egraphs-good/egglog-experimental/blob/main/tests/web-demo/get-size.egg) | `(get-size!)` returns the total number of tuples; `(get-size! "table"...)` sums only the named tables. It can be used in schedule guards. |
-| Table statistics | `(print-table-stats)` reports every visible function table; `(print-table-stats Table)` reports one. Output includes row counts, distinct values per column, and out-degree distributions. |
-
-See the [crate documentation](https://docs.rs/egglog-experimental) for Rust APIs
-and the [`tests/web-demo`](https://github.com/egraphs-good/egglog-experimental/tree/main/tests/web-demo)
-directory for runnable examples. User-facing changes are recorded in the
-[changelog](CHANGELOG.md).
+Check out the crate documentation (built locally) for the current list of implemented extensions, API details, and demo links.
+Releases are coordinated with compatible releases of egglog.

--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ egglog-experimental = "1.0"
 ## Documentation
 
 Check out the crate documentation (built locally) for the current list of implemented extensions, API details, and demo links.
-We plan to do a release on crates.io with the release of egglog 2.0.
+Releases are coordinated with compatible releases of egglog.

--- a/src/keep_best.rs
+++ b/src/keep_best.rs
@@ -17,6 +17,11 @@ use egglog::{
     span,
 };
 
+/// User-defined command implementing `(keep-best "table"...)`.
+///
+/// For every row in the named tables, the command extracts the best term for
+/// each value. It then **clears every function in the e-graph** and reinserts
+/// only the extracted rows from the named tables.
 pub struct KeepBestCommand;
 
 impl UserDefinedCommand for KeepBestCommand {

--- a/src/keep_best.rs
+++ b/src/keep_best.rs
@@ -95,11 +95,11 @@ fn collect_and_extract(
             .get_function(table_name)
             .ok_or_else(|| TypeError::UnboundFunction(table_name.clone(), span!()))?;
 
-        let all_sorts: Vec<ArcSort> = func
-            .schema()
+        let func_type = func.func_type();
+        let all_sorts: Vec<ArcSort> = func_type
             .input
             .iter()
-            .chain(std::iter::once(&func.schema().output))
+            .chain(std::iter::once(&func_type.output))
             .cloned()
             .collect();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,30 +7,17 @@
 //!
 //! ## Implemented extensions
 //!
-//! - [`for`-loops](https://egraphs-good.github.io/egglog-demo/?example=for)
-//! - [`with-ruleset`](https://egraphs-good.github.io/egglog-demo/?example=with-ruleset)
-//! - [Rationals support](https://egraphs-good.github.io/egglog-demo/?example=rational)
-//!   (see [`rational`] for the exposed primitives)
-//! - [Dynamic cost models with `set-cost`](https://egraphs-good.github.io/egglog-demo/?example=05-cost-model-and-extraction)
-//! - [Custom schedulers via `run-with`](https://egraphs-good.github.io/egglog-demo/?example=math-backoff),
-//!   including top-level `(let-scheduler name ...)` bindings stored on the e-graph
-//! - An extended `run-schedule` command (see [`scheduling`]) with `seq`,
-//!   `saturate`, `repeat`, `eval`, and forwarded commands
-//! - [`(get-size!)` primitive](https://github.com/egraphs-good/egglog-experimental/blob/main/tests/web-demo/node-limit.egg)
-//!   for inspecting total tuple counts or counts for specific tables
-//! - [Multi-extraction](https://github.com/egraphs-good/egglog-experimental/blob/main/tests/web-demo/multi-extract.egg)
-//! - Body-defined primitives with `(primitive name (InputSort*) OutputSort body)`.
-//!   Body variables are positional (`_0`, `_1`, ...), and a partial primitive
-//!   body result propagates as primitive failure. The registered primitive uses
-//!   the minimum capability needed by its body (`pure`, `read`, `write`, or
-//!   `full`). Bodies may call built-in or previously registered primitives,
-//!   table-backed functions, and globals; applying those primitives is allowed
-//!   only in a compatible runtime context. A global reference makes the defined
-//!   primitive read-capable because globals lower to zero-argument function
-//!   lookups.
+//! - Language and values: exact rationals, one-shot `for` rules, grouped
+//!   `with-ruleset` declarations, body-defined primitives, and fresh values in
+//!   rule actions.
+//! - Scheduling and extraction: extended schedules, named back-off schedulers,
+//!   dynamic costs, multi-extraction, and `keep-best` compaction.
+//! - Inspection: table-size queries and per-table column and out-degree
+//!   statistics.
 //!
-//! Each bullet links to a runnable demo so you can explore the feature quickly.
-//! The rest of this crate exposes the Rust APIs and helpers that back these extensions.
+//! The [feature guide](https://github.com/egraphs-good/egglog-experimental#features)
+//! gives concise syntax and runnable examples. This crate's modules document
+//! the Rust APIs behind the extensions.
 //!
 use egglog::ast::Parser;
 use egglog::prelude::add_base_sort;
@@ -61,6 +48,7 @@ pub use sugar::*;
 mod keep_best;
 pub use keep_best::KeepBestCommand;
 
+/// Creates an [`EGraph`] with every egglog-experimental extension registered.
 pub fn new_experimental_egraph() -> EGraph {
     let mut egraph = EGraph::default();
 
@@ -108,7 +96,9 @@ pub fn new_experimental_egraph() -> EGraph {
     egraph
 }
 
-// Create a parser with experimental macros
+/// Creates a parser with the `for` and `with-ruleset` parse-time macros.
+///
+/// Use [`new_experimental_egraph`] to register all runtime extensions as well.
 pub fn experimental_parser() -> Parser {
     let mut parser = Parser::default();
     parser.add_command_macro(Arc::new(sugar::For));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,23 +1,49 @@
+#![warn(missing_docs)]
 //! # egglog-experimental
 //!
-//! This crate layers several experimental features on top of the core
-//! [`egglog`](https://github.com/egraphs-good/egglog) language and runtime.
-//! It can serve as a standard library when building equality
-//! saturation workflows in Rust.
+//! Experimental extensions to the [`egglog`] language and runtime.
 //!
-//! ## Implemented extensions
+//! Start with [`new_experimental_egraph`] to get an e-graph with every
+//! extension registered:
 //!
-//! - Language and values: exact rationals, one-shot `for` rules, grouped
-//!   `with-ruleset` declarations, body-defined primitives, and fresh values in
-//!   rule actions.
-//! - Scheduling and extraction: extended schedules, named back-off schedulers,
-//!   dynamic costs, multi-extraction, and `keep-best` compaction.
-//! - Inspection: table-size queries and per-table column and out-degree
+//! ```
+//! use egglog_experimental::new_experimental_egraph;
+//!
+//! let mut egraph = new_experimental_egraph();
+//! egraph.parse_and_run_program(
+//!     None,
+//!     "(datatype Math (Num i64)) (extract (Num 1))",
+//! )?;
+//! # Ok::<(), egglog_experimental::Error>(())
+//! ```
+//!
+//! ## Language and values
+//!
+//! - [`RationalSort`] adds exact `Rational` values and numeric primitives.
+//! - [`For`] implements `(for (fact...) (action...))`, a rule that runs once
+//!   over the current matches.
+//! - [`WithRuleset`] groups rules and rewrites with
+//!   `(with-ruleset name command...)`.
+//! - `(primitive name (InputSort...) OutputSort body)` defines a primitive in
+//!   egglog. Body arguments are named `_0`, `_1`, and so on; calls to existing
+//!   primitives, functions, and globals determine the required access mode.
+//! - `(unstable-fresh! Sort [:cost N] [:unextractable])` creates a fresh value
+//!   for each match of a rule action.
+//!
+//! ## Scheduling and extraction
+//!
+//! - [`scheduling`] documents the extended `run-schedule` language and named
+//!   schedulers.
+//! - [`DynamicCostModel`] supports runtime costs declared with
+//!   `with-dynamic-cost` and changed with `set-cost`.
+//! - [`MultiExtract`] implements `(multi-extract n term...)`.
+//! - [`KeepBestCommand`] compacts selected tables to their best terms.
+//!
+//! ## Inspection
+//!
+//! - [`GetSizePrimitive`] implements `(get-size! "table"...)`.
+//! - [`PrintTableStatsCommand`] reports table cardinality and out-degree
 //!   statistics.
-//!
-//! The [feature guide](https://github.com/egraphs-good/egglog-experimental#features)
-//! gives concise syntax and runnable examples. This crate's modules document
-//! the Rust APIs behind the extensions.
 //!
 use egglog::ast::Parser;
 use egglog::prelude::add_base_sort;
@@ -48,7 +74,11 @@ pub use sugar::*;
 mod keep_best;
 pub use keep_best::KeepBestCommand;
 
-/// Creates an [`EGraph`] with every egglog-experimental extension registered.
+/// Creates a default [`EGraph`] with every experimental extension registered.
+///
+/// This is the recommended entry point for running egglog programs that use
+/// this crate. Use [`experimental_parser`] instead when only the parse-time
+/// `for` and `with-ruleset` macros are needed.
 pub fn new_experimental_egraph() -> EGraph {
     let mut egraph = EGraph::default();
 

--- a/src/multi_extract.rs
+++ b/src/multi_extract.rs
@@ -1,11 +1,8 @@
-//! An implementation of multi-extraction for egraphs.
-//! Adds support for extracting multiple terms with a single command,
-//! reducing the overhead of creating an extractor for each term.
-//! The syntax for multi-extraction is `(multi-extract n t1 ... tm)`,
-//! where n must be a positive i64.
-//! This command will extract n lowest-cost variants of each of the m terms.
-//! `(multi-extract 1 t)` is equivalent to `(extract t)`. Unlike
-//! `(extract t 0)`, `(multi-extract 0 t)` is rejected.
+//! Extract multiple terms or variants with one extractor pass.
+//!
+//! `(multi-extract n term...)` prints the `n` lowest-cost variants of every
+//! term. `n` must be a positive `i64`; `(multi-extract 1 term)` is equivalent
+//! to best extraction.
 
 use egglog::{
     CommandOutput, EGraph, Error, TermDag, TermId, TypeError, UserDefinedCommand,
@@ -16,6 +13,7 @@ use egglog::{
 use log::log_enabled;
 use std::{fmt::Debug, marker::PhantomData};
 
+/// Displayable output produced by [`MultiExtract`].
 #[derive(Debug)]
 pub struct MultiExtractOutput {
     termdag: TermDag,
@@ -36,6 +34,11 @@ impl std::fmt::Display for MultiExtractOutput {
     }
 }
 
+/// User-defined command implementing `(multi-extract n term...)` with a
+/// caller-provided cost model.
+///
+/// The positive `i64` value `n` is the number of variants returned for each
+/// term. All terms share one extractor computation.
 pub struct MultiExtract<C: Cost + Ord + Eq + Clone + Debug + Send + Sync, CM: CostModel<C> + Clone>
 {
     cost_model: CM,
@@ -45,6 +48,7 @@ pub struct MultiExtract<C: Cost + Ord + Eq + Clone + Debug + Send + Sync, CM: Co
 impl<C: Cost + Ord + Eq + Clone + Debug + Send + Sync, CM: CostModel<C> + Clone>
     MultiExtract<C, CM>
 {
+    /// Creates a multi-extraction command that uses `cost_model`.
     pub fn new(cost_model: CM) -> Self {
         MultiExtract {
             cost_model,

--- a/src/rational.rs
+++ b/src/rational.rs
@@ -1,14 +1,32 @@
+//! Exact rational numbers for egglog programs.
+//!
+//! [`RationalSort`] registers the `Rational` sort and these overloaded
+//! primitives:
+//!
+//! - `(rational numerator denominator)` constructs a value; the denominator
+//!   must be nonzero.
+//! - `+`, `-`, `*`, `/`, `min`, `max`, `neg`, and `abs` perform arithmetic.
+//! - `<`, `>`, `<=`, and `>=` compare values.
+//! - `floor`, `ceil`, `round`, `numer`, `denom`, and `to-f64` inspect or
+//!   convert values.
+//! - `pow` and `sqrt` return a result only when it is exactly representable.
+//!   `log` and `cbrt` currently support only the value one.
+//!
+//! [`new_experimental_egraph`] registers this sort automatically.
+
 use egglog::prelude::BaseSort;
 use egglog::sort::{BaseValues, Boxed, F, OrderedFloat};
 use num::integer::Roots;
 use num::rational::Rational64;
 use num::traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, One, Signed, ToPrimitive, Zero};
 
+/// Rust representation of an egglog `Rational` value.
 pub type R = Boxed<Rational64>;
 use crate::ast::Literal;
 
 use super::*;
 
+/// The egglog `Rational` base sort and its primitive operations.
 #[derive(Debug)]
 pub struct RationalSort;
 

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -18,8 +18,9 @@
 //! - **`(run-with scheduler [ruleset] [:until cond])`** — like `run`, but drives
 //!   the ruleset with a named scheduler previously bound by `let-scheduler`.
 //! - **`(let-scheduler name (scheduler-kind args...))`** — bind `name` to a fresh
-//!   scheduler instance (e.g. `(back-off :match-limit 1000 :ban-length 5)`).
-//!   The binding is scoped to the enclosing `seq`/`saturate`/`repeat` block.
+//!   scheduler instance (e.g. `(back-off :match-limit 1000 :ban-length 5)`). A
+//!   binding inside `run-schedule` is scoped to its enclosing block; a top-level
+//!   binding persists on the e-graph.
 //! - **`(seq step...)`** — run each step once, in order.
 //! - **`(saturate step...)`** — repeatedly run the body until it makes no further
 //!   progress (the accumulated report's `can_stop` is set).
@@ -68,9 +69,21 @@ type PermanentSchedulerState = HashMap<String, SchedulerId>;
 /// See the [module-level documentation](self) for the full schedule language.
 pub struct RunExtendedSchedule;
 
+/// User-defined command implementing
+/// `(let-scheduler name (scheduler-kind args...))`.
+///
+/// A top-level binding persists on the e-graph and can be used by later
+/// `run-schedule` commands. See the [module documentation](self) for scoped
+/// bindings inside a schedule.
 pub struct LetSchedulerCommand;
 
+/// Factory interface for constructing a scheduler from parsed egglog
+/// arguments.
+///
+/// Scheduler registration uses [`add_scheduler_builder`], which accepts the
+/// equivalent closure directly.
 pub trait SchedulerGen {
+    /// Creates a fresh scheduler for `egraph` from `args`.
     fn new_scheduler(&self, egraph: &egglog::EGraph, args: &[Expr]) -> Box<dyn Scheduler>;
 }
 
@@ -97,6 +110,11 @@ lazy_static! {
     };
 }
 
+/// Registers a scheduler constructor for use by `let-scheduler`.
+///
+/// The builder receives the current e-graph, the scheduler expression's source
+/// span, and its unevaluated arguments. Registration is process-global;
+/// registering the same name again replaces the previous builder.
 pub fn add_scheduler_builder(name: String, builder: SchedulerBuilder) {
     scheduler_libs.lock().unwrap().insert(name, builder);
 }

--- a/src/set_cost.rs
+++ b/src/set_cost.rs
@@ -1,3 +1,19 @@
+//! Runtime-configurable extraction costs.
+//!
+//! Wrap datatype or constructor declarations in `with-dynamic-cost` to create
+//! a cost table for each extractable constructor. `set-cost` updates a node's
+//! cost, and the replacement `extract` command reads those costs:
+//!
+//! ```text
+//! (with-dynamic-cost
+//!   (datatype Math (Num i64) (Add Math Math)))
+//! (set-cost (Num 1) 100)
+//! (extract (Num 1))
+//! ```
+//!
+//! Nodes without an assigned dynamic cost retain their normal tree-additive
+//! cost. Costs must be non-negative.
+
 use crate::Error;
 use egglog::{
     CommandOutput, EGraph, RawValues, Read, TermDag, TermId, UserDefinedCommand,
@@ -10,6 +26,11 @@ use egglog_ast::span::Span;
 use log::log_enabled;
 use std::sync::Arc;
 
+/// Registers `with-dynamic-cost`, `set-cost`, and the dynamic-cost `extract`
+/// command on an e-graph.
+///
+/// [`new_experimental_egraph`](crate::new_experimental_egraph) calls this
+/// automatically.
 pub fn add_set_cost(egraph: &mut EGraph) {
     egraph
         .parser
@@ -177,8 +198,11 @@ fn map_fallible<T>(
         .collect::<Result<_, _>>()
 }
 
-/// The cost model that handles dynamic costs. Use this cost model if you use the `with-dynamic-cost` / `set-cost`
-/// extensions in your egglog program
+/// An extraction cost model that reads costs assigned by `set-cost`.
+///
+/// It falls back to [`TreeAdditiveCostModel`] for constructors without an
+/// assigned dynamic cost. Use this model for custom extractors that should
+/// agree with this crate's replacement `extract` command.
 #[derive(Clone)]
 pub struct DynamicCostModel;
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -1,3 +1,10 @@
+//! Inspect e-graph table sizes from an egglog expression.
+//!
+//! `(get-size!)` returns the sum of all non-internal table sizes.
+//! `(get-size! "A" "B")` returns the sum for the named tables. The primitive
+//! is read-capable, so it can also be used in extended schedule guards and
+//! `eval` steps.
+
 use std::convert::TryFrom;
 
 use egglog::{
@@ -9,6 +16,10 @@ use egglog::{
     util::INTERNAL_SYMBOL_PREFIX,
 };
 
+/// Read primitive implementing `(get-size! "table"...)`.
+///
+/// With no arguments it sums all non-internal tables. String arguments limit
+/// the sum to the named tables.
 #[derive(Clone)]
 pub struct GetSizePrimitive;
 

--- a/src/sugar/for.rs
+++ b/src/sugar/for.rs
@@ -1,6 +1,15 @@
 use egglog::{ast::*, util::FreshGen};
 use egglog_ast::span::Span;
 
+/// Parse-time macro for applying actions once to all current query matches.
+///
+/// ```text
+/// (for ((source x))
+///      ((destination x)))
+/// ```
+///
+/// The macro creates a temporary ruleset containing one rule and runs that
+/// ruleset for one iteration.
 pub struct For;
 
 impl Macro<Vec<Command>> for For {

--- a/src/sugar/with_ruleset.rs
+++ b/src/sugar/with_ruleset.rs
@@ -1,6 +1,16 @@
 use egglog::ast::*;
 use egglog_ast::span::Span;
 
+/// Parse-time macro for assigning several rules or rewrites to one ruleset.
+///
+/// ```text
+/// (with-ruleset simplify
+///   (rewrite (Add x (Num 0)) x)
+///   (birewrite (Add x y) (Add y x)))
+/// ```
+///
+/// The body accepts `rule`, `rewrite`, and `birewrite` declarations that do
+/// not already name a ruleset.
 pub struct WithRuleset;
 
 impl Macro<Vec<Command>> for WithRuleset {

--- a/src/table_stats.rs
+++ b/src/table_stats.rs
@@ -83,10 +83,14 @@ pub struct TableStats {
 /// S-expression so it composes with the rest of egglog's output format.
 #[derive(Debug)]
 pub struct TableStatsOutput {
+    /// Statistics in the same order they are rendered.
     pub stats: Vec<TableStats>,
 }
 
 /// User-defined command implementing `(print-table-stats <name>?)`.
+///
+/// With no argument it reports every visible function table. One unquoted
+/// function name limits the report to that table.
 pub struct PrintTableStatsCommand;
 
 impl OutDegreeStats {

--- a/src/table_stats.rs
+++ b/src/table_stats.rs
@@ -215,11 +215,15 @@ fn compute_table_stats(egraph: &EGraph, func_name: &str) -> Result<TableStats, E
     let func = egraph
         .get_function(func_name)
         .ok_or_else(|| TypeError::UnboundFunction(func_name.to_owned(), Span::Panic))?;
-    let schema = func.schema();
-    let mut column_types: Vec<String> = schema.input.iter().map(|s| s.name().to_owned()).collect();
-    column_types.push(schema.output.name().to_owned());
+    let func_type = func.func_type();
+    let mut column_types: Vec<String> = func_type
+        .input
+        .iter()
+        .map(|s| s.name().to_owned())
+        .collect();
+    column_types.push(func_type.output.name().to_owned());
     let n_cols = column_types.len();
-    let n_inputs = schema.input.len();
+    let n_inputs = func_type.input.len();
     let output_col = n_cols - 1;
     let track_combined = n_inputs >= 2;
 


### PR DESCRIPTION
## Summary

- bump egglog-experimental to 3.0.0, keeping its major version aligned with egglog
- depend on the published egglog 3.0.0 crate family while pinning repository development to the v3.0.0 release commit
- migrate `Function::schema()` call sites to the egglog 3.0 `FuncType` API
- add the 3.0.0 changelog
- polish crate, module, and public-item rustdoc; add a checked getting-started example and enforce documentation on public APIs
- refresh the lockfile and README version example

## Validation

- `cargo test --release` (39 file tests, 41 integration tests, 8 fresh-value tests, 1 doctest)
- `cargo fmt --check`
- `cargo clippy --tests -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- `cargo publish --dry-run`