### PR TITLE
Size-aware back-off scheduling and DAG extraction output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ This file records notable user-facing changes to egglog-experimental.
 
 ## [Unreleased]
 
+### Added
+
+- `:node-limit` and `:eager-apply` options for the `back-off` scheduler:
+  `:node-limit N` keeps the e-graph within `N` e-nodes while choosing matches;
+  with `:eager-apply`, each rule's chosen matches are applied before the next
+  rule is consulted, so the limit is checked against the live e-graph size.
+- The `(get-node-size!)` primitive: the e-node count of the e-graph (rows of
+  eq-sort tables), the same measure `:node-limit` uses.
+- A `:dag` option for `multi-extract` that let-binds subterms shared across
+  the extracted variants instead of expanding every variant to a tree, plus
+  the underlying `dag_print` printing functions.
+
 ## [3.0.0] - 2026-08-20
 
 This is the first crates.io release of egglog-experimental. Its major version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,10 @@ This file records notable user-facing changes to egglog-experimental.
 
 ### Added
 
-- `:node-limit` and `:eager-apply` options for the `back-off` scheduler:
-  `:node-limit N` stops applying matches once the e-graph reaches `N` e-nodes,
-  checked against the size at the start of each iteration; with
-  `:eager-apply`, each rule's chosen matches are applied before the next rule
-  is consulted, so the check sees the live size and the limit is overshot by
-  at most one rule's matches.
+- A `:node-limit N` option for the `back-off` scheduler: it stops applying
+  matches once the e-graph reaches `N` e-nodes. egglog applies each rule's
+  chosen matches before the next rule is consulted, so the check sees the
+  live size and the limit is overshot by at most one rule's matches.
 - The `(get-node-size!)` primitive: the e-node count of the e-graph (rows of
   constructor tables, excluding `relation`s and functions to base sorts), the
   same measure `:node-limit` uses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ This file records notable user-facing changes to egglog-experimental.
 ### Added
 
 - `:node-limit` and `:eager-apply` options for the `back-off` scheduler:
-  `:node-limit N` keeps the e-graph within `N` e-nodes while choosing matches;
-  with `:eager-apply`, each rule's chosen matches are applied before the next
-  rule is consulted, so the limit is checked against the live e-graph size.
+  `:node-limit N` stops applying matches once the e-graph reaches `N` e-nodes,
+  checked against the size at the start of each iteration; with
+  `:eager-apply`, each rule's chosen matches are applied before the next rule
+  is consulted, so the check sees the live size and the limit is overshot by
+  at most one rule's matches.
 - The `(get-node-size!)` primitive: the e-node count of the e-graph (rows of
   eq-sort tables), the same measure `:node-limit` uses.
 - A `:dag` option for `multi-extract` that let-binds subterms shared across

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,21 @@ This file records notable user-facing changes to egglog-experimental.
 
 ### Added
 
-- A `:node-limit N` option for the `back-off` scheduler: it stops applying
-  matches once the e-graph reaches `N` e-nodes. egglog applies each rule's
-  chosen matches before the next rule is consulted, so the check sees the
-  live size and the limit is overshot by at most one rule's matches.
-- The `(get-node-size!)` primitive: the e-node count of the e-graph (rows of
-  constructor tables, excluding `relation`s and functions to base sorts), the
-  same measure `:node-limit` uses.
+- A `:node-limit N` option for the `back-off` scheduler: once an observed count
+  reaches this soft threshold, further rules are delayed. Each check sees
+  earlier rule actions, but one rule may add any number of nodes and the
+  deferred rebuild may change the count again.
+- The `(get-node-size!)` primitive: the visible constructor-row count of an
+  ordinary experimental e-graph, excluding relations, analysis functions,
+  global aliases, hidden declarations, and internal-prefixed implementation
+  tables. This is the same measure `:node-limit` uses there.
 - A `:dag` option for `multi-extract` that let-binds subterms shared across
-  the extracted variants instead of expanding every variant to a tree, plus
-  the underlying `dag_print` printing functions.
+  the extracted variants instead of expanding every variant to a tree.
+
+### Changed
+
+- The `back-off` scheduler now rejects unknown option tags instead of silently
+  ignoring misspellings or removed options.
 
 ## [3.0.0] - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ This file records notable user-facing changes to egglog-experimental.
   is consulted, so the check sees the live size and the limit is overshot by
   at most one rule's matches.
 - The `(get-node-size!)` primitive: the e-node count of the e-graph (rows of
-  eq-sort tables), the same measure `:node-limit` uses.
+  constructor tables, excluding `relation`s and functions to base sorts), the
+  same measure `:node-limit` uses.
 - A `:dag` option for `multi-extract` that let-binds subterms shared across
   the extracted variants instead of expanding every variant to a tree, plus
   the underlying `dag_print` printing functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This file records notable user-facing changes to egglog-experimental.
   reaches this soft threshold, further rules are delayed. Each check sees
   earlier rule actions, but one rule may add any number of nodes and the
   deferred rebuild may change the count again.
-- The `(get-node-size!)` primitive: the visible constructor-row count of an
+- The `(get-node-size!)` primitive: the visible e-node count of an
   ordinary experimental e-graph, excluding relations, analysis functions,
   global aliases, hidden declarations, and internal-prefixed implementation
   tables. This is the same measure `:node-limit` uses there.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=14c051b5d466f92c49733b235c7a50e8025af809#14c051b5d466f92c49733b235c7a50e8025af809"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=078c96a6ff138386add0330e0f8cac1b895b993b#078c96a6ff138386add0330e0f8cac1b895b993b"
 dependencies = [
  "chrono",
  "clap",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=14c051b5d466f92c49733b235c7a50e8025af809#14c051b5d466f92c49733b235c7a50e8025af809"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=078c96a6ff138386add0330e0f8cac1b895b993b#078c96a6ff138386add0330e0f8cac1b895b993b"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -373,7 +373,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=14c051b5d466f92c49733b235c7a50e8025af809#14c051b5d466f92c49733b235c7a50e8025af809"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=078c96a6ff138386add0330e0f8cac1b895b993b#078c96a6ff138386add0330e0f8cac1b895b993b"
 dependencies = [
  "ordered-float",
 ]
@@ -381,7 +381,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=14c051b5d466f92c49733b235c7a50e8025af809#14c051b5d466f92c49733b235c7a50e8025af809"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=078c96a6ff138386add0330e0f8cac1b895b993b#078c96a6ff138386add0330e0f8cac1b895b993b"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=14c051b5d466f92c49733b235c7a50e8025af809#14c051b5d466f92c49733b235c7a50e8025af809"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=078c96a6ff138386add0330e0f8cac1b895b993b#078c96a6ff138386add0330e0f8cac1b895b993b"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -416,7 +416,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=14c051b5d466f92c49733b235c7a50e8025af809#14c051b5d466f92c49733b235c7a50e8025af809"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=078c96a6ff138386add0330e0f8cac1b895b993b#078c96a6ff138386add0330e0f8cac1b895b993b"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -458,12 +458,12 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=14c051b5d466f92c49733b235c7a50e8025af809#14c051b5d466f92c49733b235c7a50e8025af809"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=078c96a6ff138386add0330e0f8cac1b895b993b#078c96a6ff138386add0330e0f8cac1b895b993b"
 
 [[package]]
 name = "egglog-reports"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=14c051b5d466f92c49733b235c7a50e8025af809#14c051b5d466f92c49733b235c7a50e8025af809"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=078c96a6ff138386add0330e0f8cac1b895b993b#078c96a6ff138386add0330e0f8cac1b895b993b"
 dependencies = [
  "clap",
  "hashbrown 0.16.1",
@@ -477,7 +477,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=14c051b5d466f92c49733b235c7a50e8025af809#14c051b5d466f92c49733b235c7a50e8025af809"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=078c96a6ff138386add0330e0f8cac1b895b993b#078c96a6ff138386add0330e0f8cac1b895b993b"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "3.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=ea9f1fa9b39cf330fc96ea553386a0c6802b07a6#ea9f1fa9b39cf330fc96ea553386a0c6802b07a6"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=c96c0e6a7ef60d102ab482a141b2996e0cddbc2f#c96c0e6a7ef60d102ab482a141b2996e0cddbc2f"
 dependencies = [
  "chrono",
  "clap",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "3.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=ea9f1fa9b39cf330fc96ea553386a0c6802b07a6#ea9f1fa9b39cf330fc96ea553386a0c6802b07a6"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=c96c0e6a7ef60d102ab482a141b2996e0cddbc2f#c96c0e6a7ef60d102ab482a141b2996e0cddbc2f"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -373,7 +373,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "3.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=ea9f1fa9b39cf330fc96ea553386a0c6802b07a6#ea9f1fa9b39cf330fc96ea553386a0c6802b07a6"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=c96c0e6a7ef60d102ab482a141b2996e0cddbc2f#c96c0e6a7ef60d102ab482a141b2996e0cddbc2f"
 dependencies = [
  "ordered-float",
 ]
@@ -381,7 +381,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "3.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=ea9f1fa9b39cf330fc96ea553386a0c6802b07a6#ea9f1fa9b39cf330fc96ea553386a0c6802b07a6"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=c96c0e6a7ef60d102ab482a141b2996e0cddbc2f#c96c0e6a7ef60d102ab482a141b2996e0cddbc2f"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "3.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=ea9f1fa9b39cf330fc96ea553386a0c6802b07a6#ea9f1fa9b39cf330fc96ea553386a0c6802b07a6"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=c96c0e6a7ef60d102ab482a141b2996e0cddbc2f#c96c0e6a7ef60d102ab482a141b2996e0cddbc2f"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -416,7 +416,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "3.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=ea9f1fa9b39cf330fc96ea553386a0c6802b07a6#ea9f1fa9b39cf330fc96ea553386a0c6802b07a6"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=c96c0e6a7ef60d102ab482a141b2996e0cddbc2f#c96c0e6a7ef60d102ab482a141b2996e0cddbc2f"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -458,12 +458,12 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "3.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=ea9f1fa9b39cf330fc96ea553386a0c6802b07a6#ea9f1fa9b39cf330fc96ea553386a0c6802b07a6"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=c96c0e6a7ef60d102ab482a141b2996e0cddbc2f#c96c0e6a7ef60d102ab482a141b2996e0cddbc2f"
 
 [[package]]
 name = "egglog-reports"
 version = "3.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=ea9f1fa9b39cf330fc96ea553386a0c6802b07a6#ea9f1fa9b39cf330fc96ea553386a0c6802b07a6"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=c96c0e6a7ef60d102ab482a141b2996e0cddbc2f#c96c0e6a7ef60d102ab482a141b2996e0cddbc2f"
 dependencies = [
  "clap",
  "hashbrown 0.16.1",
@@ -477,7 +477,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "3.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=ea9f1fa9b39cf330fc96ea553386a0c6802b07a6#ea9f1fa9b39cf330fc96ea553386a0c6802b07a6"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=c96c0e6a7ef60d102ab482a141b2996e0cddbc2f#c96c0e6a7ef60d102ab482a141b2996e0cddbc2f"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=a46f24b98d14422677958d257a17455a97d2ba42#a46f24b98d14422677958d257a17455a97d2ba42"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=584f1c03053bb1db8b25375c1b0b962e3afe3cf0#584f1c03053bb1db8b25375c1b0b962e3afe3cf0"
 dependencies = [
  "chrono",
  "clap",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=a46f24b98d14422677958d257a17455a97d2ba42#a46f24b98d14422677958d257a17455a97d2ba42"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=584f1c03053bb1db8b25375c1b0b962e3afe3cf0#584f1c03053bb1db8b25375c1b0b962e3afe3cf0"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -373,7 +373,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=a46f24b98d14422677958d257a17455a97d2ba42#a46f24b98d14422677958d257a17455a97d2ba42"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=584f1c03053bb1db8b25375c1b0b962e3afe3cf0#584f1c03053bb1db8b25375c1b0b962e3afe3cf0"
 dependencies = [
  "ordered-float",
 ]
@@ -381,7 +381,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=a46f24b98d14422677958d257a17455a97d2ba42#a46f24b98d14422677958d257a17455a97d2ba42"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=584f1c03053bb1db8b25375c1b0b962e3afe3cf0#584f1c03053bb1db8b25375c1b0b962e3afe3cf0"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=a46f24b98d14422677958d257a17455a97d2ba42#a46f24b98d14422677958d257a17455a97d2ba42"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=584f1c03053bb1db8b25375c1b0b962e3afe3cf0#584f1c03053bb1db8b25375c1b0b962e3afe3cf0"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -416,7 +416,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=a46f24b98d14422677958d257a17455a97d2ba42#a46f24b98d14422677958d257a17455a97d2ba42"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=584f1c03053bb1db8b25375c1b0b962e3afe3cf0#584f1c03053bb1db8b25375c1b0b962e3afe3cf0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -458,12 +458,12 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=a46f24b98d14422677958d257a17455a97d2ba42#a46f24b98d14422677958d257a17455a97d2ba42"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=584f1c03053bb1db8b25375c1b0b962e3afe3cf0#584f1c03053bb1db8b25375c1b0b962e3afe3cf0"
 
 [[package]]
 name = "egglog-reports"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=a46f24b98d14422677958d257a17455a97d2ba42#a46f24b98d14422677958d257a17455a97d2ba42"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=584f1c03053bb1db8b25375c1b0b962e3afe3cf0#584f1c03053bb1db8b25375c1b0b962e3afe3cf0"
 dependencies = [
  "clap",
  "hashbrown 0.16.1",
@@ -477,7 +477,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=a46f24b98d14422677958d257a17455a97d2ba42#a46f24b98d14422677958d257a17455a97d2ba42"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=584f1c03053bb1db8b25375c1b0b962e3afe3cf0#584f1c03053bb1db8b25375c1b0b962e3afe3cf0"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=584f1c03053bb1db8b25375c1b0b962e3afe3cf0#584f1c03053bb1db8b25375c1b0b962e3afe3cf0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0#c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0"
 dependencies = [
  "chrono",
  "clap",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=584f1c03053bb1db8b25375c1b0b962e3afe3cf0#584f1c03053bb1db8b25375c1b0b962e3afe3cf0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0#c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -373,7 +373,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=584f1c03053bb1db8b25375c1b0b962e3afe3cf0#584f1c03053bb1db8b25375c1b0b962e3afe3cf0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0#c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0"
 dependencies = [
  "ordered-float",
 ]
@@ -381,7 +381,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=584f1c03053bb1db8b25375c1b0b962e3afe3cf0#584f1c03053bb1db8b25375c1b0b962e3afe3cf0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0#c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=584f1c03053bb1db8b25375c1b0b962e3afe3cf0#584f1c03053bb1db8b25375c1b0b962e3afe3cf0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0#c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -416,7 +416,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=584f1c03053bb1db8b25375c1b0b962e3afe3cf0#584f1c03053bb1db8b25375c1b0b962e3afe3cf0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0#c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -458,12 +458,12 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=584f1c03053bb1db8b25375c1b0b962e3afe3cf0#584f1c03053bb1db8b25375c1b0b962e3afe3cf0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0#c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0"
 
 [[package]]
 name = "egglog-reports"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=584f1c03053bb1db8b25375c1b0b962e3afe3cf0#584f1c03053bb1db8b25375c1b0b962e3afe3cf0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0#c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0"
 dependencies = [
  "clap",
  "hashbrown 0.16.1",
@@ -477,7 +477,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=584f1c03053bb1db8b25375c1b0b962e3afe3cf0#584f1c03053bb1db8b25375c1b0b962e3afe3cf0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0#c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "3.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=c96c0e6a7ef60d102ab482a141b2996e0cddbc2f#c96c0e6a7ef60d102ab482a141b2996e0cddbc2f"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=2a18ca5e22b4587eee5a176529f0ce1d084d5c25#2a18ca5e22b4587eee5a176529f0ce1d084d5c25"
 dependencies = [
  "chrono",
  "clap",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "3.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=c96c0e6a7ef60d102ab482a141b2996e0cddbc2f#c96c0e6a7ef60d102ab482a141b2996e0cddbc2f"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=2a18ca5e22b4587eee5a176529f0ce1d084d5c25#2a18ca5e22b4587eee5a176529f0ce1d084d5c25"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -373,7 +373,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "3.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=c96c0e6a7ef60d102ab482a141b2996e0cddbc2f#c96c0e6a7ef60d102ab482a141b2996e0cddbc2f"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=2a18ca5e22b4587eee5a176529f0ce1d084d5c25#2a18ca5e22b4587eee5a176529f0ce1d084d5c25"
 dependencies = [
  "ordered-float",
 ]
@@ -381,7 +381,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "3.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=c96c0e6a7ef60d102ab482a141b2996e0cddbc2f#c96c0e6a7ef60d102ab482a141b2996e0cddbc2f"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=2a18ca5e22b4587eee5a176529f0ce1d084d5c25#2a18ca5e22b4587eee5a176529f0ce1d084d5c25"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "3.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=c96c0e6a7ef60d102ab482a141b2996e0cddbc2f#c96c0e6a7ef60d102ab482a141b2996e0cddbc2f"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=2a18ca5e22b4587eee5a176529f0ce1d084d5c25#2a18ca5e22b4587eee5a176529f0ce1d084d5c25"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -416,7 +416,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "3.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=c96c0e6a7ef60d102ab482a141b2996e0cddbc2f#c96c0e6a7ef60d102ab482a141b2996e0cddbc2f"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=2a18ca5e22b4587eee5a176529f0ce1d084d5c25#2a18ca5e22b4587eee5a176529f0ce1d084d5c25"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -458,12 +458,12 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "3.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=c96c0e6a7ef60d102ab482a141b2996e0cddbc2f#c96c0e6a7ef60d102ab482a141b2996e0cddbc2f"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=2a18ca5e22b4587eee5a176529f0ce1d084d5c25#2a18ca5e22b4587eee5a176529f0ce1d084d5c25"
 
 [[package]]
 name = "egglog-reports"
 version = "3.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=c96c0e6a7ef60d102ab482a141b2996e0cddbc2f#c96c0e6a7ef60d102ab482a141b2996e0cddbc2f"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=2a18ca5e22b4587eee5a176529f0ce1d084d5c25#2a18ca5e22b4587eee5a176529f0ce1d084d5c25"
 dependencies = [
  "clap",
  "hashbrown 0.16.1",
@@ -477,7 +477,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "3.0.0"
-source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=c96c0e6a7ef60d102ab482a141b2996e0cddbc2f#c96c0e6a7ef60d102ab482a141b2996e0cddbc2f"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=2a18ca5e22b4587eee5a176529f0ce1d084d5c25#2a18ca5e22b4587eee5a176529f0ce1d084d5c25"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0#c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=14c051b5d466f92c49733b235c7a50e8025af809#14c051b5d466f92c49733b235c7a50e8025af809"
 dependencies = [
  "chrono",
  "clap",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0#c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=14c051b5d466f92c49733b235c7a50e8025af809#14c051b5d466f92c49733b235c7a50e8025af809"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -373,7 +373,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0#c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=14c051b5d466f92c49733b235c7a50e8025af809#14c051b5d466f92c49733b235c7a50e8025af809"
 dependencies = [
  "ordered-float",
 ]
@@ -381,7 +381,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0#c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=14c051b5d466f92c49733b235c7a50e8025af809#14c051b5d466f92c49733b235c7a50e8025af809"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0#c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=14c051b5d466f92c49733b235c7a50e8025af809#14c051b5d466f92c49733b235c7a50e8025af809"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -416,7 +416,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0#c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=14c051b5d466f92c49733b235c7a50e8025af809#14c051b5d466f92c49733b235c7a50e8025af809"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -458,12 +458,12 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0#c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=14c051b5d466f92c49733b235c7a50e8025af809#14c051b5d466f92c49733b235c7a50e8025af809"
 
 [[package]]
 name = "egglog-reports"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0#c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=14c051b5d466f92c49733b235c7a50e8025af809#14c051b5d466f92c49733b235c7a50e8025af809"
 dependencies = [
  "clap",
  "hashbrown 0.16.1",
@@ -477,7 +477,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0#c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=14c051b5d466f92c49733b235c7a50e8025af809#14c051b5d466f92c49733b235c7a50e8025af809"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=078c96a6ff138386add0330e0f8cac1b895b993b#078c96a6ff138386add0330e0f8cac1b895b993b"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=924b5cd0f203542a097a800239100633d3c0f2b4#924b5cd0f203542a097a800239100633d3c0f2b4"
 dependencies = [
  "chrono",
  "clap",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=078c96a6ff138386add0330e0f8cac1b895b993b#078c96a6ff138386add0330e0f8cac1b895b993b"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=924b5cd0f203542a097a800239100633d3c0f2b4#924b5cd0f203542a097a800239100633d3c0f2b4"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -373,7 +373,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=078c96a6ff138386add0330e0f8cac1b895b993b#078c96a6ff138386add0330e0f8cac1b895b993b"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=924b5cd0f203542a097a800239100633d3c0f2b4#924b5cd0f203542a097a800239100633d3c0f2b4"
 dependencies = [
  "ordered-float",
 ]
@@ -381,7 +381,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=078c96a6ff138386add0330e0f8cac1b895b993b#078c96a6ff138386add0330e0f8cac1b895b993b"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=924b5cd0f203542a097a800239100633d3c0f2b4#924b5cd0f203542a097a800239100633d3c0f2b4"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=078c96a6ff138386add0330e0f8cac1b895b993b#078c96a6ff138386add0330e0f8cac1b895b993b"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=924b5cd0f203542a097a800239100633d3c0f2b4#924b5cd0f203542a097a800239100633d3c0f2b4"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -416,7 +416,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=078c96a6ff138386add0330e0f8cac1b895b993b#078c96a6ff138386add0330e0f8cac1b895b993b"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=924b5cd0f203542a097a800239100633d3c0f2b4#924b5cd0f203542a097a800239100633d3c0f2b4"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -458,12 +458,12 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=078c96a6ff138386add0330e0f8cac1b895b993b#078c96a6ff138386add0330e0f8cac1b895b993b"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=924b5cd0f203542a097a800239100633d3c0f2b4#924b5cd0f203542a097a800239100633d3c0f2b4"
 
 [[package]]
 name = "egglog-reports"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=078c96a6ff138386add0330e0f8cac1b895b993b#078c96a6ff138386add0330e0f8cac1b895b993b"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=924b5cd0f203542a097a800239100633d3c0f2b4#924b5cd0f203542a097a800239100633d3c0f2b4"
 dependencies = [
  "clap",
  "hashbrown 0.16.1",
@@ -477,7 +477,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=078c96a6ff138386add0330e0f8cac1b895b993b#078c96a6ff138386add0330e0f8cac1b895b993b"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=924b5cd0f203542a097a800239100633d3c0f2b4#924b5cd0f203542a097a800239100633d3c0f2b4"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=924b5cd0f203542a097a800239100633d3c0f2b4#924b5cd0f203542a097a800239100633d3c0f2b4"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=ea9f1fa9b39cf330fc96ea553386a0c6802b07a6#ea9f1fa9b39cf330fc96ea553386a0c6802b07a6"
 dependencies = [
  "chrono",
  "clap",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=924b5cd0f203542a097a800239100633d3c0f2b4#924b5cd0f203542a097a800239100633d3c0f2b4"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=ea9f1fa9b39cf330fc96ea553386a0c6802b07a6#ea9f1fa9b39cf330fc96ea553386a0c6802b07a6"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -373,7 +373,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=924b5cd0f203542a097a800239100633d3c0f2b4#924b5cd0f203542a097a800239100633d3c0f2b4"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=ea9f1fa9b39cf330fc96ea553386a0c6802b07a6#ea9f1fa9b39cf330fc96ea553386a0c6802b07a6"
 dependencies = [
  "ordered-float",
 ]
@@ -381,7 +381,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=924b5cd0f203542a097a800239100633d3c0f2b4#924b5cd0f203542a097a800239100633d3c0f2b4"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=ea9f1fa9b39cf330fc96ea553386a0c6802b07a6#ea9f1fa9b39cf330fc96ea553386a0c6802b07a6"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=924b5cd0f203542a097a800239100633d3c0f2b4#924b5cd0f203542a097a800239100633d3c0f2b4"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=ea9f1fa9b39cf330fc96ea553386a0c6802b07a6#ea9f1fa9b39cf330fc96ea553386a0c6802b07a6"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -416,7 +416,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=924b5cd0f203542a097a800239100633d3c0f2b4#924b5cd0f203542a097a800239100633d3c0f2b4"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=ea9f1fa9b39cf330fc96ea553386a0c6802b07a6#ea9f1fa9b39cf330fc96ea553386a0c6802b07a6"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -458,12 +458,12 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=924b5cd0f203542a097a800239100633d3c0f2b4#924b5cd0f203542a097a800239100633d3c0f2b4"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=ea9f1fa9b39cf330fc96ea553386a0c6802b07a6#ea9f1fa9b39cf330fc96ea553386a0c6802b07a6"
 
 [[package]]
 name = "egglog-reports"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=924b5cd0f203542a097a800239100633d3c0f2b4#924b5cd0f203542a097a800239100633d3c0f2b4"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=ea9f1fa9b39cf330fc96ea553386a0c6802b07a6#ea9f1fa9b39cf330fc96ea553386a0c6802b07a6"
 dependencies = [
  "clap",
  "hashbrown 0.16.1",
@@ -477,7 +477,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=924b5cd0f203542a097a800239100633d3c0f2b4#924b5cd0f203542a097a800239100633d3c0f2b4"
+source = "git+https://github.com/saulshanabrook/egg-smol.git?rev=ea9f1fa9b39cf330fc96ea553386a0c6802b07a6#ea9f1fa9b39cf330fc96ea553386a0c6802b07a6"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "egglog"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=8879605cafad303db25787406163a7e5bc845f5d#8879605cafad303db25787406163a7e5bc845f5d"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=a46f24b98d14422677958d257a17455a97d2ba42#a46f24b98d14422677958d257a17455a97d2ba42"
 dependencies = [
  "chrono",
  "clap",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "egglog-add-primitive"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=8879605cafad303db25787406163a7e5bc845f5d#8879605cafad303db25787406163a7e5bc845f5d"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=a46f24b98d14422677958d257a17455a97d2ba42#a46f24b98d14422677958d257a17455a97d2ba42"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -373,7 +373,7 @@ dependencies = [
 [[package]]
 name = "egglog-ast"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=8879605cafad303db25787406163a7e5bc845f5d#8879605cafad303db25787406163a7e5bc845f5d"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=a46f24b98d14422677958d257a17455a97d2ba42#a46f24b98d14422677958d257a17455a97d2ba42"
 dependencies = [
  "ordered-float",
 ]
@@ -381,7 +381,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=8879605cafad303db25787406163a7e5bc845f5d#8879605cafad303db25787406163a7e5bc845f5d"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=a46f24b98d14422677958d257a17455a97d2ba42#a46f24b98d14422677958d257a17455a97d2ba42"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "egglog-concurrency"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=8879605cafad303db25787406163a7e5bc845f5d#8879605cafad303db25787406163a7e5bc845f5d"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=a46f24b98d14422677958d257a17455a97d2ba42#a46f24b98d14422677958d257a17455a97d2ba42"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -416,7 +416,7 @@ dependencies = [
 [[package]]
 name = "egglog-core-relations"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=8879605cafad303db25787406163a7e5bc845f5d#8879605cafad303db25787406163a7e5bc845f5d"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=a46f24b98d14422677958d257a17455a97d2ba42#a46f24b98d14422677958d257a17455a97d2ba42"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -458,12 +458,12 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=8879605cafad303db25787406163a7e5bc845f5d#8879605cafad303db25787406163a7e5bc845f5d"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=a46f24b98d14422677958d257a17455a97d2ba42#a46f24b98d14422677958d257a17455a97d2ba42"
 
 [[package]]
 name = "egglog-reports"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=8879605cafad303db25787406163a7e5bc845f5d#8879605cafad303db25787406163a7e5bc845f5d"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=a46f24b98d14422677958d257a17455a97d2ba42#a46f24b98d14422677958d257a17455a97d2ba42"
 dependencies = [
  "clap",
  "hashbrown 0.16.1",
@@ -477,7 +477,7 @@ dependencies = [
 [[package]]
 name = "egglog-union-find"
 version = "3.0.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=8879605cafad303db25787406163a7e5bc845f5d#8879605cafad303db25787406163a7e5bc845f5d"
+source = "git+https://github.com/egraphs-good/egglog.git?rev=a46f24b98d14422677958d257a17455a97d2ba42#a46f24b98d14422677958d257a17455a97d2ba42"
 dependencies = [
  "crossbeam",
  "egglog-concurrency",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "8879605cafad303db25787406163a7e5bc845f5d", default-features = false }
-egglog-ast = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "8879605cafad303db25787406163a7e5bc845f5d", default-features = false }
-egglog-reports = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "8879605cafad303db25787406163a7e5bc845f5d", default-features = false }
+egglog = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "a46f24b98d14422677958d257a17455a97d2ba42", default-features = false }
+egglog-ast = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "a46f24b98d14422677958d257a17455a97d2ba42", default-features = false }
+egglog-reports = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "a46f24b98d14422677958d257a17455a97d2ba42", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { version = "3.0.0", git = "https://github.com/saulshanabrook/egg-smol.git", rev = "c96c0e6a7ef60d102ab482a141b2996e0cddbc2f", default-features = false }
-egglog-ast = { version = "3.0.0", git = "https://github.com/saulshanabrook/egg-smol.git", rev = "c96c0e6a7ef60d102ab482a141b2996e0cddbc2f", default-features = false }
-egglog-reports = { version = "3.0.0", git = "https://github.com/saulshanabrook/egg-smol.git", rev = "c96c0e6a7ef60d102ab482a141b2996e0cddbc2f", default-features = false }
+egglog = { version = "3.0.0", git = "https://github.com/saulshanabrook/egg-smol.git", rev = "2a18ca5e22b4587eee5a176529f0ce1d084d5c25", default-features = false }
+egglog-ast = { version = "3.0.0", git = "https://github.com/saulshanabrook/egg-smol.git", rev = "2a18ca5e22b4587eee5a176529f0ce1d084d5c25", default-features = false }
+egglog-reports = { version = "3.0.0", git = "https://github.com/saulshanabrook/egg-smol.git", rev = "2a18ca5e22b4587eee5a176529f0ce1d084d5c25", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { version = "3.0.0", git = "https://github.com/saulshanabrook/egg-smol.git", rev = "ea9f1fa9b39cf330fc96ea553386a0c6802b07a6", default-features = false }
-egglog-ast = { version = "3.0.0", git = "https://github.com/saulshanabrook/egg-smol.git", rev = "ea9f1fa9b39cf330fc96ea553386a0c6802b07a6", default-features = false }
-egglog-reports = { version = "3.0.0", git = "https://github.com/saulshanabrook/egg-smol.git", rev = "ea9f1fa9b39cf330fc96ea553386a0c6802b07a6", default-features = false }
+egglog = { version = "3.0.0", git = "https://github.com/saulshanabrook/egg-smol.git", rev = "c96c0e6a7ef60d102ab482a141b2996e0cddbc2f", default-features = false }
+egglog-ast = { version = "3.0.0", git = "https://github.com/saulshanabrook/egg-smol.git", rev = "c96c0e6a7ef60d102ab482a141b2996e0cddbc2f", default-features = false }
+egglog-reports = { version = "3.0.0", git = "https://github.com/saulshanabrook/egg-smol.git", rev = "c96c0e6a7ef60d102ab482a141b2996e0cddbc2f", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "924b5cd0f203542a097a800239100633d3c0f2b4", default-features = false }
-egglog-ast = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "924b5cd0f203542a097a800239100633d3c0f2b4", default-features = false }
-egglog-reports = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "924b5cd0f203542a097a800239100633d3c0f2b4", default-features = false }
+egglog = { version = "3.0.0", git = "https://github.com/saulshanabrook/egg-smol.git", rev = "ea9f1fa9b39cf330fc96ea553386a0c6802b07a6", default-features = false }
+egglog-ast = { version = "3.0.0", git = "https://github.com/saulshanabrook/egg-smol.git", rev = "ea9f1fa9b39cf330fc96ea553386a0c6802b07a6", default-features = false }
+egglog-reports = { version = "3.0.0", git = "https://github.com/saulshanabrook/egg-smol.git", rev = "ea9f1fa9b39cf330fc96ea553386a0c6802b07a6", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "584f1c03053bb1db8b25375c1b0b962e3afe3cf0", default-features = false }
-egglog-ast = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "584f1c03053bb1db8b25375c1b0b962e3afe3cf0", default-features = false }
-egglog-reports = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "584f1c03053bb1db8b25375c1b0b962e3afe3cf0", default-features = false }
+egglog = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0", default-features = false }
+egglog-ast = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0", default-features = false }
+egglog-reports = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "a46f24b98d14422677958d257a17455a97d2ba42", default-features = false }
-egglog-ast = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "a46f24b98d14422677958d257a17455a97d2ba42", default-features = false }
-egglog-reports = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "a46f24b98d14422677958d257a17455a97d2ba42", default-features = false }
+egglog = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "584f1c03053bb1db8b25375c1b0b962e3afe3cf0", default-features = false }
+egglog-ast = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "584f1c03053bb1db8b25375c1b0b962e3afe3cf0", default-features = false }
+egglog-reports = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "584f1c03053bb1db8b25375c1b0b962e3afe3cf0", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "078c96a6ff138386add0330e0f8cac1b895b993b", default-features = false }
-egglog-ast = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "078c96a6ff138386add0330e0f8cac1b895b993b", default-features = false }
-egglog-reports = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "078c96a6ff138386add0330e0f8cac1b895b993b", default-features = false }
+egglog = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "924b5cd0f203542a097a800239100633d3c0f2b4", default-features = false }
+egglog-ast = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "924b5cd0f203542a097a800239100633d3c0f2b4", default-features = false }
+egglog-reports = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "924b5cd0f203542a097a800239100633d3c0f2b4", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0", default-features = false }
-egglog-ast = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0", default-features = false }
-egglog-reports = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "c7eb6dd6e8a2e50920b3a1012c94a202a8e428e0", default-features = false }
+egglog = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "14c051b5d466f92c49733b235c7a50e8025af809", default-features = false }
+egglog-ast = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "14c051b5d466f92c49733b235c7a50e8025af809", default-features = false }
+egglog-reports = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "14c051b5d466f92c49733b235c7a50e8025af809", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default = ["bin"]
 bin = ["egglog/bin"]
 
 [dependencies]
-egglog = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "14c051b5d466f92c49733b235c7a50e8025af809", default-features = false }
-egglog-ast = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "14c051b5d466f92c49733b235c7a50e8025af809", default-features = false }
-egglog-reports = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "14c051b5d466f92c49733b235c7a50e8025af809", default-features = false }
+egglog = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "078c96a6ff138386add0330e0f8cac1b895b993b", default-features = false }
+egglog-ast = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "078c96a6ff138386add0330e0f8cac1b895b993b", default-features = false }
+egglog-reports = { version = "3.0.0", git = "https://github.com/egraphs-good/egglog.git", rev = "078c96a6ff138386add0330e0f8cac1b895b993b", default-features = false }
 
 num = "0.4.3"
 lazy_static = "1.4"

--- a/src/dag_print.rs
+++ b/src/dag_print.rs
@@ -1,0 +1,164 @@
+//! Compact DAG printing for [`TermDag`] terms: subterms shared across the
+//! printed roots are let-bound once instead of expanded at every use.
+//!
+//! Extraction results are highly shared — the variants of one e-class mostly
+//! differ near the root, and different roots share leaves and common
+//! subexpressions — so expanding every term to a tree can blow the printed
+//! size up by orders of magnitude relative to the underlying [`TermDag`].
+//! The functions here print a set of terms against a single sequence of let
+//! bindings instead:
+//!
+//! - a binding is introduced only for an `App` term that is referenced two or
+//!   more times across all printed terms; everything else is inlined, so
+//!   unshared output looks exactly like the ordinary printed form;
+//! - binding names are `?t0`, `?t1`, ... in dependency order: a definition
+//!   may reference earlier names, like `let*`;
+//! - the printed size is `O(|TermDag|)` instead of the sum of the expanded
+//!   tree sizes.
+
+use std::collections::{HashMap, HashSet};
+use std::fmt::Write;
+
+use egglog::{Term, TermDag, TermId};
+
+/// Render `roots` against a single shared sequence of let bindings.
+///
+/// Returns the ordered `(name, definition)` bindings and the rendered string
+/// for each root, in order. A root that is itself bound renders as its
+/// binding name.
+pub fn render_terms_with_shared_lets(
+    termdag: &TermDag,
+    roots: &[TermId],
+) -> (Vec<(String, String)>, Vec<String>) {
+    // Reference counts over the DAG: one per child slot of each distinct
+    // reachable `App`, plus one per root occurrence — i.e., how many times
+    // each term would be printed if nothing were bound.
+    let mut counts: HashMap<TermId, usize> = HashMap::new();
+    let mut seen: HashSet<TermId> = HashSet::new();
+    let mut reachable: Vec<TermId> = Vec::new();
+    let mut stack: Vec<TermId> = Vec::new();
+    for &root in roots {
+        *counts.entry(root).or_insert(0) += 1;
+        stack.push(root);
+    }
+    while let Some(id) = stack.pop() {
+        if !seen.insert(id) {
+            continue;
+        }
+        reachable.push(id);
+        if let Term::App(_, children) = termdag.get(id) {
+            for &child in children {
+                *counts.entry(child).or_insert(0) += 1;
+                stack.push(child);
+            }
+        }
+    }
+    // A term's children always have smaller ids, so ascending id order is
+    // dependency order.
+    reachable.sort_unstable();
+
+    let mut bindings: Vec<(String, String)> = Vec::new();
+    // How a use site refers to each term: its binding name, or its full
+    // rendition inlined.
+    let mut repr: HashMap<TermId, String> = HashMap::new();
+    for &id in &reachable {
+        let term = termdag.get(id);
+        let rendered = match term {
+            Term::Lit(lit) => format!("{lit}"),
+            Term::Var(v) => v.clone(),
+            Term::App(name, children) => {
+                let mut s = String::new();
+                write!(s, "({name}").unwrap();
+                for child in children {
+                    s.push(' ');
+                    s.push_str(&repr[child]);
+                }
+                s.push(')');
+                s
+            }
+        };
+        if matches!(term, Term::App(..)) && counts[&id] >= 2 {
+            let name = format!("?t{}", bindings.len());
+            bindings.push((name.clone(), rendered));
+            repr.insert(id, name);
+        } else {
+            repr.insert(id, rendered);
+        }
+    }
+
+    let rendered_roots = roots.iter().map(|r| repr[r].clone()).collect();
+    (bindings, rendered_roots)
+}
+
+/// Render `roots` as a single `(let ((name def) ...) (root ...))`
+/// s-expression (the binding list is empty when nothing is shared).
+pub fn termdag_to_dag_string(termdag: &TermDag, roots: &[TermId]) -> String {
+    let (bindings, rendered) = render_terms_with_shared_lets(termdag, roots);
+    let mut out = String::from("(let (");
+    for (name, def) in &bindings {
+        write!(out, "\n   ({name} {def})").unwrap();
+    }
+    out.push_str(")\n (");
+    for root in &rendered {
+        write!(out, "\n   {root}").unwrap();
+    }
+    out.push_str("))");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dag() -> (TermDag, TermId, TermId) {
+        let mut td = TermDag::default();
+        let one = td.lit(egglog::ast::Literal::Int(1));
+        let two = td.lit(egglog::ast::Literal::Int(2));
+        let n1 = td.app("Num".into(), vec![one]);
+        let n2 = td.app("Num".into(), vec![two]);
+        let add = td.app("Add".into(), vec![n1, n2]);
+        let neg = td.app("Neg".into(), vec![add]);
+        (td, add, neg)
+    }
+
+    #[test]
+    fn shared_subterm_is_bound_once() {
+        let (td, add, neg) = dag();
+        let (bindings, rendered) = render_terms_with_shared_lets(&td, &[add, neg]);
+        // `add` is used twice (as a root and under Neg), so it is bound;
+        // Num/literals are used once each and stay inline.
+        assert_eq!(
+            bindings,
+            vec![("?t0".into(), "(Add (Num 1) (Num 2))".into())]
+        );
+        assert_eq!(rendered, vec!["?t0".to_string(), "(Neg ?t0)".to_string()]);
+    }
+
+    #[test]
+    fn unshared_terms_are_inlined() {
+        let (td, _, neg) = dag();
+        let (bindings, rendered) = render_terms_with_shared_lets(&td, &[neg]);
+        assert!(bindings.is_empty());
+        assert_eq!(rendered, vec!["(Neg (Add (Num 1) (Num 2)))".to_string()]);
+    }
+
+    #[test]
+    fn duplicate_children_count_as_two_references() {
+        let mut td = TermDag::default();
+        let one = td.lit(egglog::ast::Literal::Int(1));
+        let n1 = td.app("Num".into(), vec![one]);
+        let double = td.app("Add".into(), vec![n1, n1]);
+        let (bindings, rendered) = render_terms_with_shared_lets(&td, &[double]);
+        assert_eq!(bindings, vec![("?t0".into(), "(Num 1)".into())]);
+        assert_eq!(rendered, vec!["(Add ?t0 ?t0)".to_string()]);
+    }
+
+    #[test]
+    fn let_string_shape() {
+        let (td, add, neg) = dag();
+        assert_eq!(
+            termdag_to_dag_string(&td, &[add, neg]),
+            "(let (\n   (?t0 (Add (Num 1) (Num 2))))\n (\n   ?t0\n   (Neg ?t0)))"
+        );
+    }
+}

--- a/src/dag_print.rs
+++ b/src/dag_print.rs
@@ -5,8 +5,9 @@
 //! differ near the root, and different roots share leaves and common
 //! subexpressions — so expanding every term to a tree can blow the printed
 //! size up by orders of magnitude relative to the underlying [`TermDag`].
-//! The functions here print a set of terms against a single sequence of let
-//! bindings instead:
+//! [`render_terms_with_shared_lets`] renders a set of terms against a single
+//! sequence of let bindings instead (the `(let ...)` s-expression around them
+//! is assembled by the caller, e.g. `multi-extract :dag`):
 //!
 //! - a binding is introduced only for an `App` term that is referenced two or
 //!   more times across all printed terms; everything else is inlined, so
@@ -90,22 +91,6 @@ pub fn render_terms_with_shared_lets(
     (bindings, rendered_roots)
 }
 
-/// Render `roots` as a single `(let ((name def) ...) (root ...))`
-/// s-expression (the binding list is empty when nothing is shared).
-pub fn termdag_to_dag_string(termdag: &TermDag, roots: &[TermId]) -> String {
-    let (bindings, rendered) = render_terms_with_shared_lets(termdag, roots);
-    let mut out = String::from("(let (");
-    for (name, def) in &bindings {
-        write!(out, "\n   ({name} {def})").unwrap();
-    }
-    out.push_str(")\n (");
-    for root in &rendered {
-        write!(out, "\n   {root}").unwrap();
-    }
-    out.push_str("))");
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -151,14 +136,5 @@ mod tests {
         let (bindings, rendered) = render_terms_with_shared_lets(&td, &[double]);
         assert_eq!(bindings, vec![("?t0".into(), "(Num 1)".into())]);
         assert_eq!(rendered, vec!["(Add ?t0 ?t0)".to_string()]);
-    }
-
-    #[test]
-    fn let_string_shape() {
-        let (td, add, neg) = dag();
-        assert_eq!(
-            termdag_to_dag_string(&td, &[add, neg]),
-            "(let (\n   (?t0 (Add (Num 1) (Num 2))))\n (\n   ?t0\n   (Neg ?t0)))"
-        );
     }
 }

--- a/src/dag_print.rs
+++ b/src/dag_print.rs
@@ -7,18 +7,18 @@
 //! size up by orders of magnitude relative to the underlying [`TermDag`].
 //! [`render_terms_with_shared_lets`] renders a set of terms against a single
 //! sequence of let bindings instead (the `(let ...)` s-expression around them
-//! is assembled by the caller, e.g. `multi-extract :dag`):
+//! is assembled by the caller, e.g. `(multi-extract n :dag ...)`):
 //!
 //! - a binding is introduced only for an `App` term that is referenced two or
 //!   more times across all printed terms; everything else is inlined, so
 //!   unshared output looks exactly like the ordinary printed form;
-//! - binding names are `?t0`, `?t1`, ... in dependency order: a definition
-//!   may reference earlier names, like `let*`;
+//! - binding names are fresh `?t0`, `?t1`, ... names in dependency order (with
+//!   names already used by term variables skipped), so a definition may
+//!   reference earlier names, like `let*`;
 //! - the printed size is `O(|TermDag|)` instead of the sum of the expanded
 //!   tree sizes.
 
-use std::collections::{HashMap, HashSet};
-use std::fmt::Write;
+use std::collections::HashSet;
 
 use egglog::{Term, TermDag, TermId};
 
@@ -27,67 +27,80 @@ use egglog::{Term, TermDag, TermId};
 /// Returns the ordered `(name, definition)` bindings and the rendered string
 /// for each root, in order. A root that is itself bound renders as its
 /// binding name.
-pub fn render_terms_with_shared_lets(
+pub(crate) fn render_terms_with_shared_lets(
     termdag: &TermDag,
     roots: &[TermId],
 ) -> (Vec<(String, String)>, Vec<String>) {
-    // Reference counts over the DAG: one per child slot of each distinct
-    // reachable `App`, plus one per root occurrence — i.e., how many times
-    // each term would be printed if nothing were bound.
-    let mut counts: HashMap<TermId, usize> = HashMap::new();
-    let mut seen: HashSet<TermId> = HashSet::new();
-    let mut reachable: Vec<TermId> = Vec::new();
-    let mut stack: Vec<TermId> = Vec::new();
+    // Count each child edge of a distinct reachable `App`, plus each root
+    // occurrence. A repeated parent will be bound, so its children occur only
+    // in that one definition and its outgoing edges are deliberately counted
+    // once rather than once per expanded-tree occurrence.
+    // TermIds are dense arena indices, so per-term state needs no hash lookup.
+    let mut counts = vec![0; termdag.size()];
+    let mut seen = vec![false; termdag.size()];
+    let mut used_names = HashSet::new();
+    let mut reachable = Vec::new();
+    let mut stack = Vec::new();
     for &root in roots {
-        *counts.entry(root).or_insert(0) += 1;
+        counts[root] += 1;
         stack.push(root);
     }
     while let Some(id) = stack.pop() {
-        if !seen.insert(id) {
+        if seen[id] {
             continue;
         }
+        seen[id] = true;
         reachable.push(id);
-        if let Term::App(_, children) = termdag.get(id) {
-            for &child in children {
-                *counts.entry(child).or_insert(0) += 1;
-                stack.push(child);
+        match termdag.get(id) {
+            Term::Var(name) => {
+                used_names.insert(name.clone());
             }
+            Term::App(_, children) => {
+                for &child in children {
+                    counts[child] += 1;
+                    stack.push(child);
+                }
+            }
+            Term::Lit(_) => {}
         }
     }
     // A term's children always have smaller ids, so ascending id order is
     // dependency order.
     reachable.sort_unstable();
 
-    let mut bindings: Vec<(String, String)> = Vec::new();
-    // How a use site refers to each term: its binding name, or its full
-    // rendition inlined.
-    let mut repr: HashMap<TermId, String> = HashMap::new();
+    let mut projected = TermDag::default();
+    let mut projected_ids = vec![0; termdag.size()];
+    let mut bindings = Vec::new();
+    let mut next_name = 0;
     for &id in &reachable {
         let term = termdag.get(id);
-        let rendered = match term {
-            Term::Lit(lit) => format!("{lit}"),
-            Term::Var(v) => v.clone(),
-            Term::App(name, children) => {
-                let mut s = String::new();
-                write!(s, "({name}").unwrap();
-                for child in children {
-                    s.push(' ');
-                    s.push_str(&repr[child]);
-                }
-                s.push(')');
-                s
-            }
+        let projected_id = match term {
+            Term::Lit(lit) => projected.lit(lit.clone()),
+            Term::Var(name) => projected.var(name.clone()),
+            Term::App(name, children) => projected.app(
+                name.clone(),
+                children.iter().map(|&child| projected_ids[child]).collect(),
+            ),
         };
-        if matches!(term, Term::App(..)) && counts[&id] >= 2 {
-            let name = format!("?t{}", bindings.len());
-            bindings.push((name.clone(), rendered));
-            repr.insert(id, name);
+        if matches!(term, Term::App(..)) && counts[id] >= 2 {
+            let name = loop {
+                let candidate = format!("?t{next_name}");
+                next_name += 1;
+                if used_names.insert(candidate.clone()) {
+                    break candidate;
+                }
+            };
+            bindings.push((name.clone(), projected.to_string(projected_id)));
+            projected_ids[id] = projected.var(name);
         } else {
-            repr.insert(id, rendered);
+            projected_ids[id] = projected_id;
         }
     }
 
-    let rendered_roots = roots.iter().map(|r| repr[r].clone()).collect();
+    let rendered_roots = roots
+        .iter()
+        .map(|&root| projected.to_string(projected_ids[root]))
+        .collect();
     (bindings, rendered_roots)
 }
 
@@ -136,5 +149,55 @@ mod tests {
         let (bindings, rendered) = render_terms_with_shared_lets(&td, &[double]);
         assert_eq!(bindings, vec![("?t0".into(), "(Num 1)".into())]);
         assert_eq!(rendered, vec!["(Add ?t0 ?t0)".to_string()]);
+    }
+
+    #[test]
+    fn duplicate_roots_bind_the_root_without_recounting_children() {
+        let (td, _, neg) = dag();
+        let (bindings, rendered) = render_terms_with_shared_lets(&td, &[neg, neg]);
+        assert_eq!(
+            bindings,
+            vec![("?t0".into(), "(Neg (Add (Num 1) (Num 2)))".into())]
+        );
+        assert_eq!(rendered, vec!["?t0".to_string(), "?t0".to_string()]);
+    }
+
+    #[test]
+    fn nested_bindings_are_in_dependency_order() {
+        let (td, add, neg) = dag();
+        let (bindings, rendered) = render_terms_with_shared_lets(&td, &[add, neg, neg]);
+        assert_eq!(
+            bindings,
+            vec![
+                ("?t0".into(), "(Add (Num 1) (Num 2))".into()),
+                ("?t1".into(), "(Neg ?t0)".into()),
+            ]
+        );
+        assert_eq!(rendered, vec!["?t0", "?t1", "?t1"]);
+    }
+
+    #[test]
+    fn generated_names_do_not_capture_term_variables() {
+        let mut td = TermDag::default();
+        let user_var = td.var("?t0".into());
+        let shared = td.app("A".into(), vec![]);
+        let root = td.app("Pair".into(), vec![shared, user_var]);
+        let (bindings, rendered) = render_terms_with_shared_lets(&td, &[root, shared]);
+        assert_eq!(bindings, vec![("?t1".into(), "(A)".into())]);
+        assert_eq!(rendered, vec!["(Pair ?t1 ?t0)", "?t1"]);
+    }
+
+    #[test]
+    fn deep_unshared_term_renders_linearly() {
+        let depth = 20_000;
+        let mut td = TermDag::default();
+        let mut root = td.app("Z".into(), vec![]);
+        for _ in 0..depth {
+            root = td.app("F".into(), vec![root]);
+        }
+
+        let (bindings, rendered) = render_terms_with_shared_lets(&td, &[root]);
+        assert!(bindings.is_empty());
+        assert_eq!(rendered[0].len(), 4 * depth + 3);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,12 +36,13 @@
 //!   schedulers.
 //! - [`DynamicCostModel`] supports runtime costs declared with
 //!   `with-dynamic-cost` and changed with `set-cost`.
-//! - [`MultiExtract`] implements `(multi-extract n term...)`.
+//! - [`MultiExtract`] implements `(multi-extract n [:dag] term...)`.
 //! - [`KeepBestCommand`] compacts selected tables to their best terms.
 //!
 //! ## Inspection
 //!
 //! - [`GetSizePrimitive`] implements `(get-size! "table"...)`.
+//! - [`GetNodeSizePrimitive`] implements `(get-node-size!)`.
 //! - [`PrintTableStatsCommand`] reports table cardinality and out-degree
 //!   statistics.
 //!
@@ -61,7 +62,6 @@ pub use set_cost::*;
 mod multi_extract;
 pub use multi_extract::*;
 mod dag_print;
-pub use dag_print::*;
 mod size;
 pub use size::*;
 mod primitive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,8 @@ mod set_cost;
 pub use set_cost::*;
 mod multi_extract;
 pub use multi_extract::*;
+mod dag_print;
+pub use dag_print::*;
 mod size;
 pub use size::*;
 mod primitive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@ pub fn new_experimental_egraph() -> EGraph {
     // Support for set cost
     add_set_cost(&mut egraph);
     egraph.add_read_primitive(GetSizePrimitive, None);
+    egraph.add_read_primitive(GetNodeSizePrimitive, None);
 
     // unstable-fresh! macro
     egraph

--- a/src/multi_extract.rs
+++ b/src/multi_extract.rs
@@ -6,8 +6,8 @@
 //!
 //! With `:dag`, the output is one
 //! `(let ((name def) ...) ((variant ...) ...))` s-expression in which
-//! subterms shared across all variants of all terms are let-bound once (see
-//! [`crate::dag_print`]), instead of every variant being expanded to a tree.
+//! subterms shared across all variants of all terms are let-bound once, instead
+//! of every variant being expanded to a tree.
 
 use egglog::{
     CommandOutput, EGraph, Error, TermDag, TermId, TypeError, UserDefinedCommand,
@@ -30,7 +30,8 @@ impl std::fmt::Display for MultiExtractOutput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.dag {
             let roots: Vec<TermId> = self.terms.iter().flatten().copied().collect();
-            let (bindings, rendered) = crate::render_terms_with_shared_lets(&self.termdag, &roots);
+            let (bindings, rendered) =
+                crate::dag_print::render_terms_with_shared_lets(&self.termdag, &roots);
             writeln!(f, "(let (")?;
             for (name, def) in &bindings {
                 writeln!(f, "   ({name} {def})")?;
@@ -60,7 +61,7 @@ impl std::fmt::Display for MultiExtractOutput {
     }
 }
 
-/// User-defined command implementing `(multi-extract n term...)` with a
+/// User-defined command implementing `(multi-extract n [:dag] term...)` with a
 /// caller-provided cost model.
 ///
 /// The positive `i64` value `n` is the number of variants returned for each
@@ -89,32 +90,27 @@ impl<
 > UserDefinedCommand for MultiExtract<C, CM>
 {
     fn update(&self, egraph: &mut EGraph, args: &[Expr]) -> Result<Vec<CommandOutput>, Error> {
-        // `:dag` may appear anywhere among the arguments.
-        let mut dag = false;
-        let args: Vec<Expr> = args
-            .iter()
-            .filter(|arg| match arg {
-                Expr::Var(_, v) if v == ":dag" => {
-                    dag = true;
-                    false
-                }
-                _ => true,
-            })
-            .cloned()
-            .collect();
-        let args = args.as_slice();
-        if args.len() < 2 {
-            let span = args.first().map(Expr::span).unwrap_or_else(|| span!());
+        let Some((variants_expr, mut terms)) = args.split_first() else {
             return Err(Error::ParseError(ParseError(
-                span,
+                span!(),
+                "multi-extract expects at least a variant count and one expression".into(),
+            )));
+        };
+        let dag = matches!(terms.first(), Some(Expr::Var(_, option)) if option == ":dag");
+        if dag {
+            terms = &terms[1..];
+        }
+        if terms.is_empty() {
+            return Err(Error::ParseError(ParseError(
+                variants_expr.span(),
                 "multi-extract expects at least a variant count and one expression".into(),
             )));
         }
 
-        let (variants_sort, variants_value) = egraph.eval_expr(&args[0])?;
+        let (variants_sort, variants_value) = egraph.eval_expr(variants_expr)?;
         if variants_sort.name() != "i64" {
             return Err(Error::TypeError(TypeError::Mismatch {
-                expr: args[0].clone(),
+                expr: variants_expr.clone(),
                 expected: egraph.get_arcsort_by(|s| s.name() == "i64"),
                 actual: variants_sort,
             }));
@@ -123,18 +119,18 @@ impl<
         let n: i64 = egraph.value_to_base(variants_value);
         if n < 0 {
             return Err(Error::ParseError(ParseError(
-                args[0].span(),
+                variants_expr.span(),
                 "Cannot extract negative number of variants".into(),
             )));
         }
         if n == 0 {
             return Err(Error::ParseError(ParseError(
-                args[0].span(),
+                variants_expr.span(),
                 "multi-extract requires a positive number of variants".into(),
             )));
         }
 
-        let (sorts, values): (Vec<_>, Vec<_>) = args[1..]
+        let (sorts, values): (Vec<_>, Vec<_>) = terms
             .iter()
             .map(|arg| egraph.eval_expr(arg))
             .collect::<Result<_, _>>()?;

--- a/src/multi_extract.rs
+++ b/src/multi_extract.rs
@@ -1,8 +1,13 @@
 //! Extract multiple terms or variants with one extractor pass.
 //!
-//! `(multi-extract n term...)` prints the `n` lowest-cost variants of every
-//! term. `n` must be a positive `i64`; `(multi-extract 1 term)` is equivalent
-//! to best extraction.
+//! `(multi-extract n [:dag] term...)` prints the `n` lowest-cost variants of
+//! every term. `n` must be a positive `i64`; `(multi-extract 1 term)` is
+//! equivalent to best extraction.
+//!
+//! With `:dag`, the output is one
+//! `(let ((name def) ...) ((variant ...) ...))` s-expression in which
+//! subterms shared across all variants of all terms are let-bound once (see
+//! [`crate::dag_print`]), instead of every variant being expanded to a tree.
 
 use egglog::{
     CommandOutput, EGraph, Error, TermDag, TermId, TypeError, UserDefinedCommand,
@@ -18,19 +23,40 @@ use std::{fmt::Debug, marker::PhantomData};
 pub struct MultiExtractOutput {
     termdag: TermDag,
     terms: Vec<Vec<TermId>>,
+    dag: bool,
 }
 
 impl std::fmt::Display for MultiExtractOutput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "(")?;
-        for variants in &self.terms {
-            writeln!(f, "   (")?;
-            for expr in variants {
-                writeln!(f, "      {}", self.termdag.to_string(*expr))?;
+        if self.dag {
+            let roots: Vec<TermId> = self.terms.iter().flatten().copied().collect();
+            let (bindings, rendered) = crate::render_terms_with_shared_lets(&self.termdag, &roots);
+            writeln!(f, "(let (")?;
+            for (name, def) in &bindings {
+                writeln!(f, "   ({name} {def})")?;
             }
-            writeln!(f, "   )")?;
+            writeln!(f, " )")?;
+            writeln!(f, " (")?;
+            let mut next = rendered.iter();
+            for variants in &self.terms {
+                writeln!(f, "   (")?;
+                for _ in variants {
+                    writeln!(f, "      {}", next.next().unwrap())?;
+                }
+                writeln!(f, "   )")?;
+            }
+            writeln!(f, " ))")
+        } else {
+            writeln!(f, "(")?;
+            for variants in &self.terms {
+                writeln!(f, "   (")?;
+                for expr in variants {
+                    writeln!(f, "      {}", self.termdag.to_string(*expr))?;
+                }
+                writeln!(f, "   )")?;
+            }
+            writeln!(f, ")")
         }
-        writeln!(f, ")")
     }
 }
 
@@ -63,6 +89,20 @@ impl<
 > UserDefinedCommand for MultiExtract<C, CM>
 {
     fn update(&self, egraph: &mut EGraph, args: &[Expr]) -> Result<Vec<CommandOutput>, Error> {
+        // `:dag` may appear anywhere among the arguments.
+        let mut dag = false;
+        let args: Vec<Expr> = args
+            .iter()
+            .filter(|arg| match arg {
+                Expr::Var(_, v) if v == ":dag" => {
+                    dag = true;
+                    false
+                }
+                _ => true,
+            })
+            .cloned()
+            .collect();
+        let args = args.as_slice();
         if args.len() < 2 {
             let span = args.first().map(Expr::span).unwrap_or_else(|| span!());
             return Err(Error::ParseError(ParseError(
@@ -127,7 +167,11 @@ impl<
         }
 
         Ok(vec![CommandOutput::UserDefined(std::sync::Arc::from(
-            MultiExtractOutput { termdag, terms },
+            MultiExtractOutput {
+                termdag,
+                terms,
+                dag,
+            },
         ))])
     }
 }

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -507,6 +507,7 @@ mod schedulers {
             node_limit,
             eager_apply,
             stats: HashMap::new(),
+            cached_nodes: None,
         }))
     }
 
@@ -525,6 +526,11 @@ mod schedulers {
         /// live size within an iteration.
         eager_apply: bool,
         stats: HashMap<String, RuleStats>,
+        /// `num_nodes()` as of `(iteration, value)`. Counting is O(#tables),
+        /// and with eager application it is consulted once per rule; the
+        /// size only changes when a rule's matches are applied, so the
+        /// reading is reused until then (and dropped at iteration boundaries).
+        cached_nodes: Option<(usize, usize)>,
     }
 
     #[derive(Debug, Clone)]
@@ -659,7 +665,14 @@ mod schedulers {
             // With eager application this is the live size; otherwise it is
             // the size at the start of the iteration.
             if let Some(node_limit) = node_limit {
-                let nodes = ctx.egraph.num_nodes();
+                let nodes = match self.cached_nodes {
+                    Some((iteration, nodes)) if iteration == ctx.iteration => nodes,
+                    _ => {
+                        let nodes = ctx.egraph.num_nodes();
+                        self.cached_nodes = Some((ctx.iteration, nodes));
+                        nodes
+                    }
+                };
                 if nodes >= node_limit {
                     debug!(
                         "Delaying {}: at node limit ({} >= {})",
@@ -669,12 +682,18 @@ mod schedulers {
                 }
             }
 
+            // Re-borrow: the node-limit check above needed `self`.
+            let stats = self.stats.get_mut(rule).unwrap();
             stats.times_applied += 1;
             debug!(
                 "Choosing all matches for {} ({}-{})",
                 rule, stats.times_applied, stats.times_banned
             );
             matches.choose_all();
+            if total_len > 0 {
+                // Applying these matches changes the size.
+                self.cached_nodes = None;
+            }
             true
         }
     }

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -18,7 +18,7 @@
 //! - **`(run-with scheduler [ruleset] [:until cond])`** — like `run`, but drives
 //!   the ruleset with a named scheduler previously bound by `let-scheduler`.
 //! - **`(let-scheduler name (scheduler-kind args...))`** — bind `name` to a fresh
-//!   scheduler instance (e.g. `(back-off :match-limit 1000 :node-limit 5000)`). A
+//!   scheduler instance (e.g. `(back-off :match-limit 1000 :ban-length 5 :node-limit 5000)`). A
 //!   binding inside `run-schedule` is scoped to its enclosing block; a top-level
 //!   binding persists on the e-graph.
 //! - **`(seq step...)`** — run each step once, in order.

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -520,10 +520,12 @@ mod schedulers {
         let default_match_limit = parse_usize_tag(&tags, ":match-limit", span)?.unwrap_or(1000);
         let default_ban_length = parse_usize_tag(&tags, ":ban-length", span)?.unwrap_or(5);
         let node_limit = parse_usize_tag(&tags, ":node-limit", span)?;
+        let eager_apply = parse_usize_tag(&tags, ":eager-apply", span)?.is_some_and(|n| n != 0);
         Ok(Box::new(BackOffScheduler {
             default_match_limit,
             default_ban_length,
             node_limit,
+            eager_apply,
             stats: HashMap::new(),
             growth_per_match: HashMap::new(),
             nodes_at_iteration_start: 0,
@@ -542,6 +544,12 @@ mod schedulers {
         /// stays below the limit; rules consulted after the budget runs out
         /// are delayed instead of applied.
         node_limit: Option<usize>,
+        /// Apply each rule's chosen matches before the next rule is
+        /// consulted (`Scheduler::apply_immediately`). Sizes observed through
+        /// the context are then up to date within an iteration, so the
+        /// node-limit check reads them directly instead of projecting from a
+        /// growth estimate.
+        eager_apply: bool,
         stats: HashMap<String, RuleStats>,
         /// Estimated e-nodes added per approved match, keyed by ruleset (the
         /// same scheduler can drive rulesets with very different growth, e.g.
@@ -592,7 +600,10 @@ mod schedulers {
         /// in the previous iteration from the growth its approved matches
         /// actually caused.
         fn refresh_iteration(&mut self, ctx: &SchedulerContext, ruleset: &str) {
-            if self.node_limit.is_none() || self.last_seen_iteration == Some(ctx.iteration) {
+            if self.node_limit.is_none()
+                || self.eager_apply
+                || self.last_seen_iteration == Some(ctx.iteration)
+            {
                 return;
             }
             let nodes = ctx.egraph.num_nodes();
@@ -631,8 +642,8 @@ mod schedulers {
                 .copied()
                 .unwrap_or(GROWTH_PER_MATCH_INIT)
                 .max(GROWTH_PER_MATCH_BUDGET_FLOOR);
-            let projected = self.nodes_at_iteration_start as f64
-                + growth * self.approved_this_iteration as f64;
+            let projected =
+                self.nodes_at_iteration_start as f64 + growth * self.approved_this_iteration as f64;
             let remaining = node_limit as f64 - projected;
             if remaining <= 0.0 {
                 0
@@ -643,6 +654,10 @@ mod schedulers {
     }
 
     impl Scheduler for BackOffScheduler {
+        fn apply_immediately(&self) -> bool {
+            self.eager_apply
+        }
+
         fn can_stop(&mut self, ctx: &SchedulerContext, rules: &[&str], _ruleset: &str) -> bool {
             // At the node limit, further iterations cannot make progress:
             // every rule would be delayed. Report saturation even though
@@ -758,6 +773,20 @@ mod schedulers {
                 matches.choose_all();
                 return true;
             };
+
+            if self.eager_apply {
+                // Chosen matches are applied before the next rule is
+                // consulted, so the size below is up to date: check it
+                // directly instead of projecting from a growth estimate.
+                if ctx.egraph.num_nodes() >= node_limit {
+                    debug!("Delaying {}: at node limit", rule);
+                    return false;
+                }
+                self.get_stats(rule.to_owned()).times_applied += 1;
+                debug!("Choosing all matches for {}", rule);
+                matches.choose_all();
+                return true;
+            }
 
             let budget = self.match_budget(node_limit);
             if budget == 0 {

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -500,12 +500,10 @@ mod schedulers {
         let default_match_limit = parse_usize_tag(&tags, ":match-limit", span)?.unwrap_or(1000);
         let default_ban_length = parse_usize_tag(&tags, ":ban-length", span)?.unwrap_or(5);
         let node_limit = parse_usize_tag(&tags, ":node-limit", span)?;
-        let eager_apply = parse_usize_tag(&tags, ":eager-apply", span)?.is_some_and(|n| n != 0);
         Ok(Box::new(BackOffScheduler {
             default_match_limit,
             default_ban_length,
             node_limit,
-            eager_apply,
             stats: HashMap::new(),
             cached_nodes: None,
         }))
@@ -516,20 +514,16 @@ mod schedulers {
         default_match_limit: usize,
         default_ban_length: usize,
         /// Upper bound on the number of e-nodes (`EGraph::num_nodes`). Once
-        /// the e-graph reaches it, rules are delayed instead of applied.
-        /// Without `eager_apply` the size is only current at the start of
-        /// each iteration, so the limit can be overshot by one iteration's
-        /// growth; with it, by one rule's.
+        /// the e-graph reaches it, rules are delayed instead of applied. The
+        /// runner applies each rule's chosen matches before consulting the
+        /// next rule, so the check sees the live size and the limit can be
+        /// overshot by at most one rule's matches.
         node_limit: Option<usize>,
-        /// Apply each rule's chosen matches before the next rule is consulted
-        /// (`Scheduler::apply_immediately`), so the node-limit check sees the
-        /// live size within an iteration.
-        eager_apply: bool,
         stats: HashMap<String, RuleStats>,
-        /// `num_nodes()` as of `(iteration, value)`. Counting is O(#tables),
-        /// and with eager application it is consulted once per rule; the
-        /// size only changes when a rule's matches are applied, so the
-        /// reading is reused until then (and dropped at iteration boundaries).
+        /// `num_nodes()` as of `(iteration, value)`. Counting is O(#tables)
+        /// and it is consulted once per rule; the size only changes when a
+        /// rule's matches are applied, so the reading is reused until then
+        /// (and dropped at iteration boundaries).
         cached_nodes: Option<(usize, usize)>,
     }
 
@@ -557,10 +551,6 @@ mod schedulers {
     }
 
     impl Scheduler for BackOffScheduler {
-        fn apply_immediately(&self) -> bool {
-            self.eager_apply
-        }
-
         fn can_stop(&mut self, ctx: &SchedulerContext, rules: &[&str], _ruleset: &str) -> bool {
             // At the node limit, further iterations cannot make progress:
             // every rule would be delayed. Report saturation even though
@@ -662,8 +652,8 @@ mod schedulers {
                 return false;
             }
 
-            // With eager application this is the live size; otherwise it is
-            // the size at the start of the iteration.
+            // Live size: earlier rules' matches in this iteration are already
+            // applied (an upper bound until the end-of-iteration rebuild).
             if let Some(node_limit) = node_limit {
                 let nodes = match self.cached_nodes {
                     Some((iteration, nodes)) if iteration == ctx.iteration => nodes,

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -465,11 +465,51 @@ mod schedulers {
 
     use egglog::{
         ast::{Expr, Literal},
-        scheduler::{Matches, Scheduler},
+        scheduler::{Matches, Scheduler, SchedulerContext},
     };
     use log::{debug, info};
 
     use crate::parse_tags;
+
+    /// Initial estimate for how many e-nodes one fired match adds, before any
+    /// growth has been observed. Recalibrated each iteration.
+    const GROWTH_PER_MATCH_INIT: f64 = 2.0;
+    /// Clamp bounds for the observed growth rate, so a merge-heavy iteration
+    /// (which can shrink the e-graph) or one wildly-fanning rule cannot push
+    /// the estimate to a degenerate value.
+    const GROWTH_PER_MATCH_MIN: f64 = 0.1;
+    const GROWTH_PER_MATCH_MAX: f64 = 64.0;
+    /// When converting the node budget into a match budget, never assume a
+    /// match adds less than one node, even if the observed (dedup-heavy)
+    /// growth rate is lower: under-estimating growth is what overshoots the
+    /// limit.
+    const GROWTH_PER_MATCH_BUDGET_FLOOR: f64 = 1.0;
+    /// Approve at most 1/BUDGET_SAFETY of the remaining node budget per
+    /// iteration, so a mis-estimated growth rate overshoots by at most
+    /// `remaining * (actual/estimate / BUDGET_SAFETY - 1)`. The residual
+    /// matches are held (not re-queried), so approaching the limit
+    /// geometrically over a few extra iterations is cheap.
+    const BUDGET_SAFETY: f64 = 2.0;
+
+    fn parse_usize_tag(
+        tags: &HashMap<String, Literal>,
+        tag: &str,
+        span: &egglog::ast::Span,
+    ) -> Result<Option<usize>, egglog::Error> {
+        tags.get(tag)
+            .map(|lit| match lit {
+                Literal::Int(n) if *n >= 0 => Ok(*n as usize),
+                Literal::Int(_) => Err(egglog::Error::ParseError(egglog::ast::ParseError(
+                    span.clone(),
+                    format!("Scheduler {tag} must be non-negative"),
+                ))),
+                _ => Err(egglog::Error::ParseError(egglog::ast::ParseError(
+                    span.clone(),
+                    format!("Scheduler {tag} must be an integer"),
+                ))),
+            })
+            .transpose()
+    }
 
     pub(super) fn new_back_off_scheduler(
         _egraph: &egglog::EGraph,
@@ -477,40 +517,19 @@ mod schedulers {
         args: &[Expr],
     ) -> Result<Box<dyn Scheduler>, egglog::Error> {
         let tags = parse_tags(span, args)?;
-        let default_match_limit = tags
-            .get(":match-limit")
-            .map(|lit| match lit {
-                Literal::Int(n) if *n >= 0 => Ok(*n as usize),
-                Literal::Int(_) => Err(egglog::Error::ParseError(egglog::ast::ParseError(
-                    span.clone(),
-                    "Scheduler :match-limit must be non-negative".into(),
-                ))),
-                _ => Err(egglog::Error::ParseError(egglog::ast::ParseError(
-                    span.clone(),
-                    "Scheduler :match-limit must be an integer".into(),
-                ))),
-            })
-            .transpose()?
-            .unwrap_or(1000);
-        let default_ban_length = tags
-            .get(":ban-length")
-            .map(|lit| match lit {
-                Literal::Int(n) if *n >= 0 => Ok(*n as usize),
-                Literal::Int(_) => Err(egglog::Error::ParseError(egglog::ast::ParseError(
-                    span.clone(),
-                    "Scheduler :ban-length must be non-negative".into(),
-                ))),
-                _ => Err(egglog::Error::ParseError(egglog::ast::ParseError(
-                    span.clone(),
-                    "Scheduler :ban-length must be an integer".into(),
-                ))),
-            })
-            .transpose()?
-            .unwrap_or(5);
+        let default_match_limit = parse_usize_tag(&tags, ":match-limit", span)?.unwrap_or(1000);
+        let default_ban_length = parse_usize_tag(&tags, ":ban-length", span)?.unwrap_or(5);
+        let node_limit = parse_usize_tag(&tags, ":node-limit", span)?;
         Ok(Box::new(BackOffScheduler {
             default_match_limit,
             default_ban_length,
+            node_limit,
             stats: HashMap::new(),
+            growth_per_match: HashMap::new(),
+            nodes_at_iteration_start: 0,
+            approved_this_iteration: 0,
+            current_ruleset: String::new(),
+            last_seen_iteration: None,
         }))
     }
 
@@ -518,7 +537,32 @@ mod schedulers {
     pub struct BackOffScheduler {
         default_match_limit: usize,
         default_ban_length: usize,
+        /// Upper bound on the number of e-nodes (`EGraph::num_nodes`). When
+        /// set, matches are only approved while the projected e-graph size
+        /// stays below the limit; rules consulted after the budget runs out
+        /// are delayed instead of applied.
+        node_limit: Option<usize>,
         stats: HashMap<String, RuleStats>,
+        /// Estimated e-nodes added per approved match, keyed by ruleset (the
+        /// same scheduler can drive rulesets with very different growth, e.g.
+        /// rewrites versus constant folding, whose matches only union). Jumps
+        /// up immediately when growth is under-estimated and decays slowly
+        /// (EMA) when over-estimated: under-estimates are what overshoot the
+        /// node limit. Only maintained when `node_limit` is set.
+        growth_per_match: HashMap<String, f64>,
+        /// `num_nodes()` reading taken at the start of the current iteration.
+        /// Sizes reported through the context only change between iterations,
+        /// so within an iteration the projected size is this reading plus
+        /// the estimated growth of the matches approved so far.
+        nodes_at_iteration_start: usize,
+        /// Matches approved so far in the current iteration, across all rules.
+        approved_this_iteration: usize,
+        /// The ruleset the current iteration is running, i.e. the one the
+        /// approved matches (and the growth observed at the next iteration
+        /// boundary) belong to.
+        current_ruleset: String,
+        /// Which iteration the fields above refer to.
+        last_seen_iteration: Option<usize>,
     }
 
     #[derive(Debug, Clone)]
@@ -542,10 +586,74 @@ mod schedulers {
                 iteration: 0,
             })
         }
+
+        /// On the first call of a new iteration, re-read the e-graph size and
+        /// recalibrate the growth-per-match estimate of the ruleset that ran
+        /// in the previous iteration from the growth its approved matches
+        /// actually caused.
+        fn refresh_iteration(&mut self, ctx: &SchedulerContext, ruleset: &str) {
+            if self.node_limit.is_none() || self.last_seen_iteration == Some(ctx.iteration) {
+                return;
+            }
+            let nodes = ctx.egraph.num_nodes();
+            if self.last_seen_iteration.is_some() && self.approved_this_iteration > 0 {
+                let grew = nodes.saturating_sub(self.nodes_at_iteration_start);
+                let observed = (grew as f64 / self.approved_this_iteration as f64)
+                    .clamp(GROWTH_PER_MATCH_MIN, GROWTH_PER_MATCH_MAX);
+                let growth = self
+                    .growth_per_match
+                    .entry(self.current_ruleset.clone())
+                    .or_insert(GROWTH_PER_MATCH_INIT);
+                // Jump up immediately, decay slowly: an under-estimate is
+                // what overshoots the node limit.
+                *growth = if observed > *growth {
+                    observed
+                } else {
+                    0.5 * *growth + 0.5 * observed
+                };
+                debug!(
+                    "Recalibrated growth per match of {} to {:.3} ({} nodes / {} matches)",
+                    self.current_ruleset, growth, grew, self.approved_this_iteration,
+                );
+            }
+            self.nodes_at_iteration_start = nodes;
+            self.approved_this_iteration = 0;
+            self.current_ruleset = ruleset.to_owned();
+            self.last_seen_iteration = Some(ctx.iteration);
+        }
+
+        /// How many more matches fit in the node budget, given the projected
+        /// e-graph size after the matches already approved this iteration.
+        fn match_budget(&self, node_limit: usize) -> usize {
+            let growth = self
+                .growth_per_match
+                .get(&self.current_ruleset)
+                .copied()
+                .unwrap_or(GROWTH_PER_MATCH_INIT)
+                .max(GROWTH_PER_MATCH_BUDGET_FLOOR);
+            let projected = self.nodes_at_iteration_start as f64
+                + growth * self.approved_this_iteration as f64;
+            let remaining = node_limit as f64 - projected;
+            if remaining <= 0.0 {
+                0
+            } else {
+                (remaining / (BUDGET_SAFETY * growth)) as usize
+            }
+        }
     }
 
     impl Scheduler for BackOffScheduler {
-        fn can_stop(&mut self, rules: &[&str], _ruleset: &str) -> bool {
+        fn can_stop(&mut self, ctx: &SchedulerContext, rules: &[&str], _ruleset: &str) -> bool {
+            // At the node limit, further iterations cannot make progress:
+            // every rule would be delayed. Report saturation even though
+            // banned rules may be pending.
+            if let Some(node_limit) = self.node_limit {
+                let nodes = ctx.egraph.num_nodes();
+                if nodes >= node_limit {
+                    info!("Node limit reached ({nodes} >= {node_limit}); stopping");
+                    return true;
+                }
+            }
             let stats = &mut self.stats;
             let n_stats = stats.len();
 
@@ -601,40 +709,79 @@ mod schedulers {
             result
         }
 
-        fn filter_matches(&mut self, rule: &str, _ruleset: &str, matches: &mut Matches) -> bool {
-            let stats = self.get_stats(rule.to_owned());
-            stats.iteration += 1;
+        fn filter_matches(
+            &mut self,
+            ctx: &SchedulerContext,
+            rule: &str,
+            ruleset: &str,
+            matches: &mut Matches,
+        ) -> bool {
+            self.refresh_iteration(ctx, ruleset);
 
-            if stats.iteration < stats.banned_until {
-                debug!(
-                    "Skipping {} ({}-{}), banned until {}...",
-                    rule, stats.times_applied, stats.times_banned, stats.banned_until,
-                );
-                return false;
+            let total_len: usize = matches.match_size();
+            {
+                let stats = self.get_stats(rule.to_owned());
+                stats.iteration += 1;
+
+                if stats.iteration < stats.banned_until {
+                    debug!(
+                        "Skipping {} ({}-{}), banned until {}...",
+                        rule, stats.times_applied, stats.times_banned, stats.banned_until,
+                    );
+                    return false;
+                }
+
+                let threshold = stats
+                    .match_limit
+                    .checked_shl(stats.times_banned as u32)
+                    .unwrap();
+                if total_len > threshold {
+                    let ban_length = stats.ban_length << stats.times_banned;
+                    stats.times_banned += 1;
+                    stats.banned_until = stats.iteration + ban_length;
+                    info!(
+                        "Banning {} ({}-{}) for {} iters: {} < {}",
+                        rule,
+                        stats.times_applied,
+                        stats.times_banned,
+                        ban_length,
+                        threshold,
+                        total_len,
+                    );
+                    return false;
+                }
             }
 
-            let threshold = stats
-                .match_limit
-                .checked_shl(stats.times_banned as u32)
-                .unwrap();
-            let total_len: usize = matches.match_size();
-            if total_len > threshold {
-                let ban_length = stats.ban_length << stats.times_banned;
-                stats.times_banned += 1;
-                stats.banned_until = stats.iteration + ban_length;
-                info!(
-                    "Banning {} ({}-{}) for {} iters: {} < {}",
-                    rule, stats.times_applied, stats.times_banned, ban_length, threshold, total_len,
-                );
-                false
-            } else {
-                stats.times_applied += 1;
-                debug!(
-                    "Choosing all matches for {} ({}-{})",
-                    rule, stats.times_applied, stats.times_banned
-                );
+            let Some(node_limit) = self.node_limit else {
+                self.get_stats(rule.to_owned()).times_applied += 1;
+                debug!("Choosing all matches for {}", rule);
+                matches.choose_all();
+                return true;
+            };
+
+            let budget = self.match_budget(node_limit);
+            if budget == 0 {
+                debug!("Delaying {}: node budget exhausted", rule);
+                return false;
+            }
+            if total_len <= budget {
+                self.approved_this_iteration += total_len;
+                self.get_stats(rule.to_owned()).times_applied += 1;
+                debug!("Choosing all matches for {}", rule);
                 matches.choose_all();
                 true
+            } else {
+                for idx in 0..budget {
+                    matches.choose(idx);
+                }
+                self.approved_this_iteration += budget;
+                self.get_stats(rule.to_owned()).times_applied += 1;
+                info!(
+                    "Partially applying {}: {}/{} matches within node budget",
+                    rule, budget, total_len,
+                );
+                // The residual matches stay pending; do not re-run the query.
+                false
             }
         }
     }

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -18,7 +18,7 @@
 //! - **`(run-with scheduler [ruleset] [:until cond])`** — like `run`, but drives
 //!   the ruleset with a named scheduler previously bound by `let-scheduler`.
 //! - **`(let-scheduler name (scheduler-kind args...))`** — bind `name` to a fresh
-//!   scheduler instance (e.g. `(back-off :match-limit 1000 :ban-length 5)`). A
+//!   scheduler instance (e.g. `(back-off :match-limit 1000 :node-limit 5000)`). A
 //!   binding inside `run-schedule` is scoped to its enclosing block; a top-level
 //!   binding persists on the e-graph.
 //! - **`(seq step...)`** — run each step once, in order.
@@ -478,11 +478,18 @@ mod schedulers {
     ) -> Result<Option<usize>, egglog::Error> {
         tags.get(tag)
             .map(|lit| match lit {
-                Literal::Int(n) if *n >= 0 => Ok(*n as usize),
-                Literal::Int(_) => Err(egglog::Error::ParseError(egglog::ast::ParseError(
-                    span.clone(),
-                    format!("Scheduler {tag} must be non-negative"),
-                ))),
+                Literal::Int(n) if *n < 0 => {
+                    Err(egglog::Error::ParseError(egglog::ast::ParseError(
+                        span.clone(),
+                        format!("Scheduler {tag} must be non-negative"),
+                    )))
+                }
+                Literal::Int(n) => usize::try_from(*n).map_err(|_| {
+                    egglog::Error::ParseError(egglog::ast::ParseError(
+                        span.clone(),
+                        format!("Scheduler {tag} is too large for this platform"),
+                    ))
+                }),
                 _ => Err(egglog::Error::ParseError(egglog::ast::ParseError(
                     span.clone(),
                     format!("Scheduler {tag} must be an integer"),
@@ -497,6 +504,15 @@ mod schedulers {
         args: &[Expr],
     ) -> Result<Box<dyn Scheduler>, egglog::Error> {
         let tags = parse_tags(span, args)?;
+        if let Some(tag) = tags
+            .keys()
+            .find(|tag| !matches!(tag.as_str(), ":match-limit" | ":ban-length" | ":node-limit"))
+        {
+            return Err(egglog::Error::ParseError(egglog::ast::ParseError(
+                span.clone(),
+                format!("Unknown back-off scheduler tag {tag}"),
+            )));
+        }
         let default_match_limit = parse_usize_tag(&tags, ":match-limit", span)?.unwrap_or(1000);
         let default_ban_length = parse_usize_tag(&tags, ":ban-length", span)?.unwrap_or(5);
         let node_limit = parse_usize_tag(&tags, ":node-limit", span)?;
@@ -505,7 +521,6 @@ mod schedulers {
             default_ban_length,
             node_limit,
             stats: HashMap::new(),
-            cached_nodes: None,
         }))
     }
 
@@ -513,18 +528,12 @@ mod schedulers {
     pub struct BackOffScheduler {
         default_match_limit: usize,
         default_ban_length: usize,
-        /// Upper bound on the number of e-nodes (`EGraph::num_nodes`). Once
-        /// the e-graph reaches it, rules are delayed instead of applied. The
-        /// runner applies each rule's chosen matches before consulting the
-        /// next rule, so the check sees the live size and the limit can be
-        /// overshot by at most one rule's matches.
+        /// Soft threshold for the number of e-nodes. Once an observed count
+        /// reaches it, rules are delayed instead of applied. A selected rule
+        /// may insert any number of nodes, and the deferred rebuild may change
+        /// the count again.
         node_limit: Option<usize>,
         stats: HashMap<String, RuleStats>,
-        /// `num_nodes()` as of `(iteration, value)`. Counting is O(#tables)
-        /// and it is consulted once per rule; the size only changes when a
-        /// rule's matches are applied, so the reading is reused until then
-        /// (and dropped at iteration boundaries).
-        cached_nodes: Option<(usize, usize)>,
     }
 
     #[derive(Debug, Clone)]
@@ -551,12 +560,12 @@ mod schedulers {
     }
 
     impl Scheduler for BackOffScheduler {
-        fn can_stop(&mut self, ctx: &SchedulerContext, rules: &[&str], _ruleset: &str) -> bool {
+        fn can_stop(&mut self, ctx: &SchedulerContext<'_>, rules: &[&str], _ruleset: &str) -> bool {
             // At the node limit, further iterations cannot make progress:
             // every rule would be delayed. Report saturation even though
             // banned rules may be pending.
             if let Some(node_limit) = self.node_limit {
-                let nodes = ctx.egraph.num_nodes();
+                let nodes = ctx.num_nodes();
                 if nodes >= node_limit {
                     info!("Node limit reached ({nodes} >= {node_limit}); stopping");
                     return true;
@@ -619,7 +628,7 @@ mod schedulers {
 
         fn filter_matches(
             &mut self,
-            ctx: &SchedulerContext,
+            ctx: &SchedulerContext<'_>,
             rule: &str,
             _ruleset: &str,
             matches: &mut Matches,
@@ -652,17 +661,10 @@ mod schedulers {
                 return false;
             }
 
-            // Live size: earlier rules' matches in this iteration are already
-            // applied (an upper bound until the end-of-iteration rebuild).
+            // Earlier rule actions are visible here. Rebuilding may later move
+            // the count in either direction.
             if let Some(node_limit) = node_limit {
-                let nodes = match self.cached_nodes {
-                    Some((iteration, nodes)) if iteration == ctx.iteration => nodes,
-                    _ => {
-                        let nodes = ctx.egraph.num_nodes();
-                        self.cached_nodes = Some((ctx.iteration, nodes));
-                        nodes
-                    }
-                };
+                let nodes = ctx.num_nodes();
                 if nodes >= node_limit {
                     debug!(
                         "Delaying {}: at node limit ({} >= {})",
@@ -672,18 +674,12 @@ mod schedulers {
                 }
             }
 
-            // Re-borrow: the node-limit check above needed `self`.
-            let stats = self.stats.get_mut(rule).unwrap();
             stats.times_applied += 1;
             debug!(
                 "Choosing all matches for {} ({}-{})",
                 rule, stats.times_applied, stats.times_banned
             );
             matches.choose_all();
-            if total_len > 0 {
-                // Applying these matches changes the size.
-                self.cached_nodes = None;
-            }
             true
         }
     }

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -471,26 +471,6 @@ mod schedulers {
 
     use crate::parse_tags;
 
-    /// Initial estimate for how many e-nodes one fired match adds, before any
-    /// growth has been observed. Recalibrated each iteration.
-    const GROWTH_PER_MATCH_INIT: f64 = 2.0;
-    /// Clamp bounds for the observed growth rate, so a merge-heavy iteration
-    /// (which can shrink the e-graph) or one wildly-fanning rule cannot push
-    /// the estimate to a degenerate value.
-    const GROWTH_PER_MATCH_MIN: f64 = 0.1;
-    const GROWTH_PER_MATCH_MAX: f64 = 64.0;
-    /// When converting the node budget into a match budget, never assume a
-    /// match adds less than one node, even if the observed (dedup-heavy)
-    /// growth rate is lower: under-estimating growth is what overshoots the
-    /// limit.
-    const GROWTH_PER_MATCH_BUDGET_FLOOR: f64 = 1.0;
-    /// Approve at most 1/BUDGET_SAFETY of the remaining node budget per
-    /// iteration, so a mis-estimated growth rate overshoots by at most
-    /// `remaining * (actual/estimate / BUDGET_SAFETY - 1)`. The residual
-    /// matches are held (not re-queried), so approaching the limit
-    /// geometrically over a few extra iterations is cheap.
-    const BUDGET_SAFETY: f64 = 2.0;
-
     fn parse_usize_tag(
         tags: &HashMap<String, Literal>,
         tag: &str,
@@ -527,11 +507,6 @@ mod schedulers {
             node_limit,
             eager_apply,
             stats: HashMap::new(),
-            growth_per_match: HashMap::new(),
-            nodes_at_iteration_start: 0,
-            approved_this_iteration: 0,
-            current_ruleset: String::new(),
-            last_seen_iteration: None,
         }))
     }
 
@@ -539,38 +514,17 @@ mod schedulers {
     pub struct BackOffScheduler {
         default_match_limit: usize,
         default_ban_length: usize,
-        /// Upper bound on the number of e-nodes (`EGraph::num_nodes`). When
-        /// set, matches are only approved while the projected e-graph size
-        /// stays below the limit; rules consulted after the budget runs out
-        /// are delayed instead of applied.
+        /// Upper bound on the number of e-nodes (`EGraph::num_nodes`). Once
+        /// the e-graph reaches it, rules are delayed instead of applied.
+        /// Without `eager_apply` the size is only current at the start of
+        /// each iteration, so the limit can be overshot by one iteration's
+        /// growth; with it, by one rule's.
         node_limit: Option<usize>,
-        /// Apply each rule's chosen matches before the next rule is
-        /// consulted (`Scheduler::apply_immediately`). Sizes observed through
-        /// the context are then up to date within an iteration, so the
-        /// node-limit check reads them directly instead of projecting from a
-        /// growth estimate.
+        /// Apply each rule's chosen matches before the next rule is consulted
+        /// (`Scheduler::apply_immediately`), so the node-limit check sees the
+        /// live size within an iteration.
         eager_apply: bool,
         stats: HashMap<String, RuleStats>,
-        /// Estimated e-nodes added per approved match, keyed by ruleset (the
-        /// same scheduler can drive rulesets with very different growth, e.g.
-        /// rewrites versus constant folding, whose matches only union). Jumps
-        /// up immediately when growth is under-estimated and decays slowly
-        /// (EMA) when over-estimated: under-estimates are what overshoot the
-        /// node limit. Only maintained when `node_limit` is set.
-        growth_per_match: HashMap<String, f64>,
-        /// `num_nodes()` reading taken at the start of the current iteration.
-        /// Sizes reported through the context only change between iterations,
-        /// so within an iteration the projected size is this reading plus
-        /// the estimated growth of the matches approved so far.
-        nodes_at_iteration_start: usize,
-        /// Matches approved so far in the current iteration, across all rules.
-        approved_this_iteration: usize,
-        /// The ruleset the current iteration is running, i.e. the one the
-        /// approved matches (and the growth observed at the next iteration
-        /// boundary) belong to.
-        current_ruleset: String,
-        /// Which iteration the fields above refer to.
-        last_seen_iteration: Option<usize>,
     }
 
     #[derive(Debug, Clone)]
@@ -593,63 +547,6 @@ mod schedulers {
                 ban_length: self.default_ban_length,
                 iteration: 0,
             })
-        }
-
-        /// On the first call of a new iteration, re-read the e-graph size and
-        /// recalibrate the growth-per-match estimate of the ruleset that ran
-        /// in the previous iteration from the growth its approved matches
-        /// actually caused.
-        fn refresh_iteration(&mut self, ctx: &SchedulerContext, ruleset: &str) {
-            if self.node_limit.is_none()
-                || self.eager_apply
-                || self.last_seen_iteration == Some(ctx.iteration)
-            {
-                return;
-            }
-            let nodes = ctx.egraph.num_nodes();
-            if self.last_seen_iteration.is_some() && self.approved_this_iteration > 0 {
-                let grew = nodes.saturating_sub(self.nodes_at_iteration_start);
-                let observed = (grew as f64 / self.approved_this_iteration as f64)
-                    .clamp(GROWTH_PER_MATCH_MIN, GROWTH_PER_MATCH_MAX);
-                let growth = self
-                    .growth_per_match
-                    .entry(self.current_ruleset.clone())
-                    .or_insert(GROWTH_PER_MATCH_INIT);
-                // Jump up immediately, decay slowly: an under-estimate is
-                // what overshoots the node limit.
-                *growth = if observed > *growth {
-                    observed
-                } else {
-                    0.5 * *growth + 0.5 * observed
-                };
-                debug!(
-                    "Recalibrated growth per match of {} to {:.3} ({} nodes / {} matches)",
-                    self.current_ruleset, growth, grew, self.approved_this_iteration,
-                );
-            }
-            self.nodes_at_iteration_start = nodes;
-            self.approved_this_iteration = 0;
-            self.current_ruleset = ruleset.to_owned();
-            self.last_seen_iteration = Some(ctx.iteration);
-        }
-
-        /// How many more matches fit in the node budget, given the projected
-        /// e-graph size after the matches already approved this iteration.
-        fn match_budget(&self, node_limit: usize) -> usize {
-            let growth = self
-                .growth_per_match
-                .get(&self.current_ruleset)
-                .copied()
-                .unwrap_or(GROWTH_PER_MATCH_INIT)
-                .max(GROWTH_PER_MATCH_BUDGET_FLOOR);
-            let projected =
-                self.nodes_at_iteration_start as f64 + growth * self.approved_this_iteration as f64;
-            let remaining = node_limit as f64 - projected;
-            if remaining <= 0.0 {
-                0
-            } else {
-                (remaining / (BUDGET_SAFETY * growth)) as usize
-            }
         }
     }
 
@@ -728,90 +625,57 @@ mod schedulers {
             &mut self,
             ctx: &SchedulerContext,
             rule: &str,
-            ruleset: &str,
+            _ruleset: &str,
             matches: &mut Matches,
         ) -> bool {
-            self.refresh_iteration(ctx, ruleset);
-
+            let node_limit = self.node_limit;
             let total_len: usize = matches.match_size();
-            {
-                let stats = self.get_stats(rule.to_owned());
-                stats.iteration += 1;
+            let stats = self.get_stats(rule.to_owned());
+            stats.iteration += 1;
 
-                if stats.iteration < stats.banned_until {
-                    debug!(
-                        "Skipping {} ({}-{}), banned until {}...",
-                        rule, stats.times_applied, stats.times_banned, stats.banned_until,
-                    );
-                    return false;
-                }
-
-                let threshold = stats
-                    .match_limit
-                    .checked_shl(stats.times_banned as u32)
-                    .unwrap();
-                if total_len > threshold {
-                    let ban_length = stats.ban_length << stats.times_banned;
-                    stats.times_banned += 1;
-                    stats.banned_until = stats.iteration + ban_length;
-                    info!(
-                        "Banning {} ({}-{}) for {} iters: {} < {}",
-                        rule,
-                        stats.times_applied,
-                        stats.times_banned,
-                        ban_length,
-                        threshold,
-                        total_len,
-                    );
-                    return false;
-                }
-            }
-
-            let Some(node_limit) = self.node_limit else {
-                self.get_stats(rule.to_owned()).times_applied += 1;
-                debug!("Choosing all matches for {}", rule);
-                matches.choose_all();
-                return true;
-            };
-
-            if self.eager_apply {
-                // Chosen matches are applied before the next rule is
-                // consulted, so the size below is up to date: check it
-                // directly instead of projecting from a growth estimate.
-                if ctx.egraph.num_nodes() >= node_limit {
-                    debug!("Delaying {}: at node limit", rule);
-                    return false;
-                }
-                self.get_stats(rule.to_owned()).times_applied += 1;
-                debug!("Choosing all matches for {}", rule);
-                matches.choose_all();
-                return true;
-            }
-
-            let budget = self.match_budget(node_limit);
-            if budget == 0 {
-                debug!("Delaying {}: node budget exhausted", rule);
+            if stats.iteration < stats.banned_until {
+                debug!(
+                    "Skipping {} ({}-{}), banned until {}...",
+                    rule, stats.times_applied, stats.times_banned, stats.banned_until,
+                );
                 return false;
             }
-            if total_len <= budget {
-                self.approved_this_iteration += total_len;
-                self.get_stats(rule.to_owned()).times_applied += 1;
-                debug!("Choosing all matches for {}", rule);
-                matches.choose_all();
-                true
-            } else {
-                for idx in 0..budget {
-                    matches.choose(idx);
-                }
-                self.approved_this_iteration += budget;
-                self.get_stats(rule.to_owned()).times_applied += 1;
+
+            let threshold = stats
+                .match_limit
+                .checked_shl(stats.times_banned as u32)
+                .unwrap();
+            if total_len > threshold {
+                let ban_length = stats.ban_length << stats.times_banned;
+                stats.times_banned += 1;
+                stats.banned_until = stats.iteration + ban_length;
                 info!(
-                    "Partially applying {}: {}/{} matches within node budget",
-                    rule, budget, total_len,
+                    "Banning {} ({}-{}) for {} iters: {} < {}",
+                    rule, stats.times_applied, stats.times_banned, ban_length, threshold, total_len,
                 );
-                // The residual matches stay pending; do not re-run the query.
-                false
+                return false;
             }
+
+            // With eager application this is the live size; otherwise it is
+            // the size at the start of the iteration.
+            if let Some(node_limit) = node_limit {
+                let nodes = ctx.egraph.num_nodes();
+                if nodes >= node_limit {
+                    debug!(
+                        "Delaying {}: at node limit ({} >= {})",
+                        rule, nodes, node_limit
+                    );
+                    return false;
+                }
+            }
+
+            stats.times_applied += 1;
+            debug!(
+                "Choosing all matches for {} ({}-{})",
+                rule, stats.times_applied, stats.times_banned
+            );
+            matches.choose_all();
+            true
         }
     }
 }

--- a/src/size.rs
+++ b/src/size.rs
@@ -61,8 +61,9 @@ impl ReadPrim for GetSizePrimitive {
 /// `(get-node-size!)`: the number of e-nodes in the e-graph — the total row
 /// count of tables whose output is a unionable eq-sort (constructors). Unlike
 /// `(get-size!)`, this excludes analysis tables (functions to base-sort values
-/// and `relation`s), so it matches the node count of a traditional e-graph.
-/// Same measure as `egglog::EGraph::num_nodes`.
+/// and `relation`s, which desugar to constructors over a fresh non-unionable
+/// sort), so it matches the node count of a traditional e-graph. Same measure
+/// as `egglog::EGraph::num_nodes`.
 #[derive(Clone)]
 pub struct GetNodeSizePrimitive;
 
@@ -95,7 +96,7 @@ impl ReadPrim for GetNodeSizePrimitive {
                     FunctionSubtype::Constructor => state.constructor_schema(name).ok()?,
                     FunctionSubtype::Custom => state.function_schema(name).ok()?,
                 };
-                func_type.output.is_eq_sort().then_some(size)
+                state.is_sort_unionable(&func_type.output)?.then_some(size)
             })
             .sum();
         let size = i64::try_from(size).ok()?;

--- a/src/size.rs
+++ b/src/size.rs
@@ -4,7 +4,7 @@
 //! `(get-size! "A" "B")` returns the sum for the named tables. The primitive
 //! is read-capable, so it can also be used in extended schedule guards and
 //! `eval` steps.
-//! `(get-node-size!)` returns the visible constructor-node count.
+//! `(get-node-size!)` returns the visible e-node count.
 
 use std::convert::TryFrom;
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -1,9 +1,10 @@
-//! Inspect e-graph table sizes from an egglog expression.
+//! Inspect e-graph table and e-node counts from egglog expressions.
 //!
 //! `(get-size!)` returns the sum of all non-internal table sizes.
 //! `(get-size! "A" "B")` returns the sum for the named tables. The primitive
 //! is read-capable, so it can also be used in extended schedule guards and
 //! `eval` steps.
+//! `(get-node-size!)` returns the visible constructor-node count.
 
 use std::convert::TryFrom;
 
@@ -58,12 +59,13 @@ impl ReadPrim for GetSizePrimitive {
     }
 }
 
-/// `(get-node-size!)`: the number of e-nodes in the e-graph — the total row
-/// count of tables whose output is a unionable eq-sort (constructors). Unlike
-/// `(get-size!)`, this excludes analysis tables (functions to base-sort values
-/// and `relation`s, which desugar to constructors over a fresh non-unionable
-/// sort), so it matches the node count of a traditional e-graph. Same measure
-/// as `egglog::EGraph::num_nodes`.
+/// `(get-node-size!)`: the row count of visible constructor tables whose
+/// output is a unionable eq-sort.
+///
+/// Unlike `(get-size!)`, it excludes relations, analysis functions, global
+/// aliases, hidden declarations, and internal-prefixed implementation tables.
+/// On an ordinary experimental e-graph, this is the same measure as the
+/// back-off scheduler's `:node-limit`.
 #[derive(Clone)]
 pub struct GetNodeSizePrimitive;
 
@@ -89,14 +91,14 @@ impl ReadPrim for GetNodeSizePrimitive {
             .table_sizes()
             .into_iter()
             .filter_map(|(name, size)| {
-                if name.starts_with(INTERNAL_SYMBOL_PREFIX) {
+                if name.starts_with(INTERNAL_SYMBOL_PREFIX)
+                    || state.is_table_hidden(name)?
+                    || state.table_subtype(name)? != FunctionSubtype::Constructor
+                {
                     return None;
                 }
-                let func_type = match state.table_subtype(name)? {
-                    FunctionSubtype::Constructor => state.constructor_schema(name).ok()?,
-                    FunctionSubtype::Custom => state.function_schema(name).ok()?,
-                };
-                state.is_sort_unionable(&func_type.output)?.then_some(size)
+                let output = &state.constructor_schema(name).ok()?.output;
+                state.is_sort_unionable(output)?.then_some(size)
             })
             .sum();
         let size = i64::try_from(size).ok()?;

--- a/src/size.rs
+++ b/src/size.rs
@@ -59,10 +59,10 @@ impl ReadPrim for GetSizePrimitive {
 }
 
 /// `(get-node-size!)`: the number of e-nodes in the e-graph — the total row
-/// count of tables whose output is an eq-sort. Unlike `(get-size!)`, this
-/// excludes analysis tables (functions to base-sort values), so it matches the
-/// node count of a traditional e-graph. Same measure as
-/// `egglog::EGraph::num_nodes`.
+/// count of tables whose output is a unionable eq-sort (constructors). Unlike
+/// `(get-size!)`, this excludes analysis tables (functions to base-sort values
+/// and `relation`s), so it matches the node count of a traditional e-graph.
+/// Same measure as `egglog::EGraph::num_nodes`.
 #[derive(Clone)]
 pub struct GetNodeSizePrimitive;
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -59,7 +59,7 @@ impl ReadPrim for GetSizePrimitive {
     }
 }
 
-/// `(get-node-size!)`: the row count of visible constructor tables whose
+/// `(get-node-size!)`: the number of e-nodes in visible constructor tables whose
 /// output is a unionable eq-sort.
 ///
 /// Unlike `(get-size!)`, it excludes relations, analysis functions, global

--- a/src/size.rs
+++ b/src/size.rs
@@ -9,6 +9,7 @@ use std::convert::TryFrom;
 
 use egglog::{
     Core, Primitive, Read, ReadPrim, ReadState, Value,
+    ast::FunctionSubtype,
     constraint::{AllEqualTypeConstraint, TypeConstraint},
     prelude::BaseSort,
     prelude::{I64Sort, Span, StringSort},
@@ -52,6 +53,51 @@ impl ReadPrim for GetSizePrimitive {
                 .filter_map(|name| state.table_size(&name))
                 .sum(),
         };
+        let size = i64::try_from(size).ok()?;
+        Some(state.base_values().get::<i64>(size))
+    }
+}
+
+/// `(get-node-size!)`: the number of e-nodes in the e-graph — the total row
+/// count of tables whose output is an eq-sort. Unlike `(get-size!)`, this
+/// excludes analysis tables (functions to base-sort values), so it matches the
+/// node count of a traditional e-graph. Same measure as
+/// `egglog::EGraph::num_nodes`.
+#[derive(Clone)]
+pub struct GetNodeSizePrimitive;
+
+impl Primitive for GetNodeSizePrimitive {
+    fn name(&self) -> &str {
+        "get-node-size!"
+    }
+
+    fn get_type_constraints(&self, span: &Span) -> Box<dyn TypeConstraint> {
+        AllEqualTypeConstraint::new(self.name(), span.clone())
+            .with_output_sort(I64Sort.to_arcsort())
+            .with_exact_length(1)
+            .into_box()
+    }
+}
+
+impl ReadPrim for GetNodeSizePrimitive {
+    fn apply<'a, 'db>(&self, state: ReadState<'a, 'db>, args: &[Value]) -> Option<Value> {
+        if !args.is_empty() {
+            return None;
+        }
+        let size: usize = state
+            .table_sizes()
+            .into_iter()
+            .filter_map(|(name, size)| {
+                if name.starts_with(INTERNAL_SYMBOL_PREFIX) {
+                    return None;
+                }
+                let func_type = match state.table_subtype(name)? {
+                    FunctionSubtype::Constructor => state.constructor_schema(name).ok()?,
+                    FunctionSubtype::Custom => state.function_schema(name).ok()?,
+                };
+                func_type.output.is_eq_sort().then_some(size)
+            })
+            .sum();
         let size = i64::try_from(size).ok()?;
         Some(state.base_values().get::<i64>(size))
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1226,12 +1226,13 @@ fn test_backoff_node_limit() {
         .unwrap();
 
     let nodes = egraph.num_nodes();
-    // Every match in this workload adds exactly one e-node, so the growth
-    // estimate converges from above and the limit is never overshot.
-    assert!(nodes <= 500, "node limit overshot: {nodes}");
-    // The scheduler stopped because of the limit, not because the workload
-    // saturated early.
-    assert!(nodes >= 450, "stopped too early: {nodes}");
+    // The size is checked once per iteration, so the limit can be overshot by
+    // at most one iteration's growth (a few dozen nodes here), and the
+    // scheduler stopped because of the limit rather than early saturation.
+    assert!(
+        (450..=600).contains(&nodes),
+        "unexpected final size: {nodes}"
+    );
 
     // (get-node-size!) agrees with EGraph::num_nodes and, since this program
     // has no analysis tables, with (get-size!).

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1226,8 +1226,8 @@ fn test_backoff_node_limit() {
         .unwrap();
 
     let nodes = egraph.num_nodes();
-    // The size is checked once per iteration, so the limit can be overshot by
-    // at most one iteration's growth (a few dozen nodes here), and the
+    // Each rule's matches are applied before the next rule is consulted, so
+    // the limit can be overshot by at most one rule's matches, and the
     // scheduler stopped because of the limit rather than early saturation.
     assert!(
         (450..=600).contains(&nodes),
@@ -1272,36 +1272,6 @@ fn test_get_node_size_excludes_analysis_tables() {
     assert_eq!(eval_get_size(&mut egraph, &[]), 5);
     assert_eq!(egraph.num_nodes(), 2);
     assert_eq!(egraph.total_size(), 5);
-}
-
-#[test]
-fn test_backoff_node_limit_eager_apply() {
-    let mut egraph = egglog_experimental::new_experimental_egraph();
-
-    // Same workload as test_backoff_node_limit, but with :eager-apply the
-    // scheduler checks the live size before each rule instead of projecting
-    // from a growth estimate. Overshoot is bounded by one rule's match set.
-    egraph
-        .parse_and_run_program(
-            None,
-            r#"
-        (ruleset explode)
-        (datatype Math (Num i64) (Add Math Math))
-        (Num 0)
-        (rule ((= e (Num i)) (< i 200)) ((Num (+ i 1))) :ruleset explode :name "count")
-        (rule ((= a (Num x)) (= b (Num y))) ((Add a b)) :ruleset explode :name "pair")
-        (run-schedule
-          (let-scheduler bo (back-off :node-limit 500 :eager-apply 1))
-          (saturate (run-with bo explode)))
-        "#,
-        )
-        .unwrap();
-
-    let nodes = egraph.num_nodes();
-    assert!(
-        (450..=600).contains(&nodes),
-        "unexpected final size: {nodes}"
-    );
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1252,9 +1252,12 @@ fn test_get_node_size_excludes_analysis_tables() {
             r#"
         (datatype Math (Num i64))
         (function depth (Math) i64 :no-merge)
+        (relation seen (Math))
         (Num 0)
         (Num 1)
         (set (depth (Num 0)) 0)
+        (seen (Num 0))
+        (seen (Num 1))
         "#,
         )
         .unwrap();
@@ -1262,12 +1265,13 @@ fn test_get_node_size_excludes_analysis_tables() {
     let span = span!();
     let expr = Expr::Call(span.clone(), "get-node-size!".into(), vec![]);
     let (_, value) = egraph.eval_expr(&expr).unwrap();
-    // Two Num nodes; the depth analysis row is excluded.
+    // Two Num nodes; the depth analysis row and the two relation rows (a
+    // constructor over a non-unionable sort) are excluded.
     assert_eq!(egraph.value_to_base::<i64>(value), 2);
     // ... but included by (get-size!).
-    assert_eq!(eval_get_size(&mut egraph, &[]), 3);
+    assert_eq!(eval_get_size(&mut egraph, &[]), 5);
     assert_eq!(egraph.num_nodes(), 2);
-    assert_eq!(egraph.total_size(), 3);
+    assert_eq!(egraph.total_size(), 5);
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1298,3 +1298,39 @@ fn test_backoff_node_limit_eager_apply() {
         "unexpected final size: {nodes}"
     );
 }
+
+#[test]
+fn test_multi_extract_dag() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+    let outputs = egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (datatype Math (Num i64) (Add Math Math) (Neg Math))
+        (let a (Add (Num 1) (Num 2)))
+        (let b (Neg (Add (Num 1) (Num 2))))
+        (multi-extract 1 :dag a b)
+        "#,
+        )
+        .unwrap();
+    let printed = outputs.last().unwrap().to_string();
+    let tokens: Vec<&str> = printed.split_whitespace().collect();
+    // The shared (Add (Num 1) (Num 2)) is bound once; leaves stay inline.
+    assert_eq!(
+        tokens.join(" "),
+        "(let ( (?t0 (Add (Num 1) (Num 2))) ) ( ( ?t0 ) ( (Neg ?t0) ) ))"
+    );
+
+    // :dag output must expand to exactly the non-dag output.
+    let plain = egraph
+        .parse_and_run_program(None, "(multi-extract 1 a b)")
+        .unwrap()
+        .last()
+        .unwrap()
+        .to_string();
+    let plain_tokens: Vec<&str> = plain.split_whitespace().collect();
+    assert_eq!(
+        plain_tokens.join(" "),
+        "( ( (Add (Num 1) (Num 2)) ) ( (Neg (Add (Num 1) (Num 2))) ) )"
+    );
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1268,3 +1268,33 @@ fn test_get_node_size_excludes_analysis_tables() {
     assert_eq!(egraph.num_nodes(), 2);
     assert_eq!(egraph.total_size(), 3);
 }
+
+#[test]
+fn test_backoff_node_limit_eager_apply() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    // Same workload as test_backoff_node_limit, but with :eager-apply the
+    // scheduler checks the live size before each rule instead of projecting
+    // from a growth estimate. Overshoot is bounded by one rule's match set.
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (ruleset explode)
+        (datatype Math (Num i64) (Add Math Math))
+        (Num 0)
+        (rule ((= e (Num i)) (< i 200)) ((Num (+ i 1))) :ruleset explode :name "count")
+        (rule ((= a (Num x)) (= b (Num y))) ((Add a b)) :ruleset explode :name "pair")
+        (run-schedule
+          (let-scheduler bo (back-off :node-limit 500 :eager-apply 1))
+          (saturate (run-with bo explode)))
+        "#,
+        )
+        .unwrap();
+
+    let nodes = egraph.num_nodes();
+    assert!(
+        (450..=600).contains(&nodes),
+        "unexpected final size: {nodes}"
+    );
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1202,3 +1202,69 @@ fn test_schedule_commands_and_actions() {
         )
         .unwrap();
 }
+
+#[test]
+fn test_backoff_node_limit() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+
+    // "count" grows one Num per iteration; "pair" is quadratic in the number
+    // of Nums. Without a node limit this saturates at 201 Nums and ~40k Adds.
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (ruleset explode)
+        (datatype Math (Num i64) (Add Math Math))
+        (Num 0)
+        (rule ((= e (Num i)) (< i 200)) ((Num (+ i 1))) :ruleset explode :name "count")
+        (rule ((= a (Num x)) (= b (Num y))) ((Add a b)) :ruleset explode :name "pair")
+        (run-schedule
+          (let-scheduler bo (back-off :node-limit 500))
+          (saturate (run-with bo explode)))
+        "#,
+        )
+        .unwrap();
+
+    let nodes = egraph.num_nodes();
+    // Every match in this workload adds exactly one e-node, so the growth
+    // estimate converges from above and the limit is never overshot.
+    assert!(nodes <= 500, "node limit overshot: {nodes}");
+    // The scheduler stopped because of the limit, not because the workload
+    // saturated early.
+    assert!(nodes >= 450, "stopped too early: {nodes}");
+
+    // (get-node-size!) agrees with EGraph::num_nodes and, since this program
+    // has no analysis tables, with (get-size!).
+    let span = span!();
+    let expr = Expr::Call(span.clone(), "get-node-size!".into(), vec![]);
+    let (_, value) = egraph.eval_expr(&expr).unwrap();
+    assert_eq!(egraph.value_to_base::<i64>(value), nodes as i64);
+    assert_eq!(eval_get_size(&mut egraph, &[]), nodes as i64);
+}
+
+#[test]
+fn test_get_node_size_excludes_analysis_tables() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (datatype Math (Num i64))
+        (function depth (Math) i64 :no-merge)
+        (Num 0)
+        (Num 1)
+        (set (depth (Num 0)) 0)
+        "#,
+        )
+        .unwrap();
+
+    let span = span!();
+    let expr = Expr::Call(span.clone(), "get-node-size!".into(), vec![]);
+    let (_, value) = egraph.eval_expr(&expr).unwrap();
+    // Two Num nodes; the depth analysis row is excluded.
+    assert_eq!(egraph.value_to_base::<i64>(value), 2);
+    // ... but included by (get-size!).
+    assert_eq!(eval_get_size(&mut egraph, &[]), 3);
+    assert_eq!(egraph.num_nodes(), 2);
+    assert_eq!(egraph.total_size(), 3);
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -810,8 +810,24 @@ fn test_invalid_scheduler_config_returns_error_instead_of_panicking() {
 }
 
 #[test]
+fn test_unknown_backoff_tag_returns_error() {
+    for tag in [":node-limt", ":eager-apply"] {
+        let mut egraph = egglog_experimental::new_experimental_egraph();
+        let err = egraph
+            .parse_and_run_program(
+                None,
+                &format!("(run-schedule (let-scheduler bo (back-off {tag} 10)))"),
+            )
+            .unwrap_err();
+
+        assert!(err.to_string().contains("Unknown back-off scheduler tag"));
+        assert!(err.to_string().contains(tag));
+    }
+}
+
+#[test]
 fn test_negative_scheduler_config_returns_error_instead_of_panicking() {
-    for tag in [":match-limit", ":ban-length"] {
+    for tag in [":match-limit", ":ban-length", ":node-limit"] {
         let mut egraph = egglog_experimental::new_experimental_egraph();
         let err = egraph
             .parse_and_run_program(
@@ -826,7 +842,11 @@ fn test_negative_scheduler_config_returns_error_instead_of_panicking() {
 
 #[test]
 fn test_multi_extract_bad_arity_returns_error_instead_of_panicking() {
-    for program in ["(multi-extract)", "(multi-extract 1)"] {
+    for program in [
+        "(multi-extract)",
+        "(multi-extract 1)",
+        "(multi-extract 1 :dag)",
+    ] {
         let mut egraph = egglog_experimental::new_experimental_egraph();
 
         let err = egraph.parse_and_run_program(None, program).unwrap_err();
@@ -834,6 +854,23 @@ fn test_multi_extract_bad_arity_returns_error_instead_of_panicking() {
         assert!(
             err.to_string()
                 .contains("multi-extract expects at least a variant count and one expression"),
+            "unexpected error for {program}: {err}"
+        );
+    }
+}
+
+#[test]
+fn test_multi_extract_dag_only_in_documented_position() {
+    for program in ["(multi-extract 1 a :dag)", "(multi-extract 1 :dag :dag a)"] {
+        let mut egraph = egglog_experimental::new_experimental_egraph();
+        let err = egraph
+            .parse_and_run_program(
+                None,
+                &format!("(datatype Math (Num i64)) (let a (Num 1)) {program}"),
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string().contains(":dag"),
             "unexpected error for {program}: {err}"
         );
     }
@@ -1226,11 +1263,10 @@ fn test_backoff_node_limit() {
         .unwrap();
 
     let nodes = egraph.num_nodes();
-    // Each rule's matches are applied before the next rule is consulted, so
-    // the limit can be overshot by at most one rule's matches, and the
-    // scheduler stopped because of the limit rather than early saturation.
+    // This program has no node-producing merge callbacks: it reaches the soft
+    // threshold and remains within the expected final rule batch.
     assert!(
-        (450..=600).contains(&nodes),
+        (500..=600).contains(&nodes),
         "unexpected final size: {nodes}"
     );
 
@@ -1271,7 +1307,33 @@ fn test_get_node_size_excludes_analysis_tables() {
     // ... but included by (get-size!).
     assert_eq!(eval_get_size(&mut egraph, &[]), 5);
     assert_eq!(egraph.num_nodes(), 2);
-    assert_eq!(egraph.total_size(), 5);
+}
+
+#[test]
+fn test_get_node_size_excludes_custom_let_and_hidden_tables() {
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (sort S)
+        (constructor C () S)
+        (constructor Hidden () S :internal-hidden)
+        (function analysis () S :merge old)
+        (relation seen ())
+        (C)
+        (Hidden)
+        (set (analysis) (C))
+        (let root (C))
+        (seen)
+        "#,
+        )
+        .unwrap();
+
+    let expr = Expr::Call(span!(), "get-node-size!".into(), vec![]);
+    let (_, value) = egraph.eval_expr(&expr).unwrap();
+    assert_eq!(egraph.value_to_base::<i64>(value), 1);
+    assert_eq!(egraph.num_nodes(), 1);
 }
 
 #[test]


### PR DESCRIPTION
Depends on egraphs-good/egglog#1005 (currently pinned to that branch's rev; will bump to the merged rev before landing — hence draft).

## What

Three features, all motivated by Herbie's egglog backend:

1. **`(back-off :node-limit N)`** — once the e-graph reaches `N` e-nodes (`EGraph::num_nodes`), rules are delayed instead of applied, and `can_stop` reports saturation so saturating schedules terminate. egglog applies each rule's chosen matches before consulting the next rule, so the check reads the **live** e-graph size and the overshoot is bounded by one rule's matches. No growth estimation of any kind: the scheduler measures instead of predicting. The node count is cached per iteration and re-read only after a rule actually applied matches (counting is O(#tables) and is consulted once per rule).
2. (An `:eager-apply` option that selected per-rule application existed while that was opt-in in egglog; it is gone now that egglog always applies per rule.)
3. **`(multi-extract n :dag term...)`** — prints one `(let ((?tN def) ...) ((variant ...) ...))` s-expression in which App subterms referenced ≥2 times across all variants of all roots are let-bound once (dependency order, `let*`-style); literals, variables, and once-used terms stay inline. Backed by the new `dag_print` module (`render_terms_with_shared_lets`; the `(let ...)` wrapper is assembled by `multi-extract` itself).

Plus **`(get-node-size!)`**: the e-node count — the same measure `:node-limit` uses, for `:until` guards; unlike `(get-size!)` it excludes analysis tables (functions to base sorts and `relation`s, via egglog's new `Read::is_sort_unionable`).

## Results (Herbie bench/numerics, 155 rewriting runs, node limit 4000)

Size control (final e-nodes on limit-hitting runs):

| scheduler | overshoot median / max |
| --- | --- |
| back-off, limit checked once per iteration (an `:until` guard) | +93% / +472% |
| `:node-limit` (live check) | **+4% / +53%** — matches egg on the same inputs |

At node limit 50,000 the live check stays at +7% max and is the fastest configuration overall; per-rule application itself costs nothing single-threaded (0.96–1.00× batched on identical scheduling decisions) and 0–7% wall with 8 threads. (A growth-estimating variant was tried and removed: it reached +5%/+93% at 4000 but was punctured to +56% at 50,000, and a static per-rule bound is not a true bound since primitives can create arbitrarily many nodes.)

Extraction output with `:dag`: variants share most of their structure, so expanded trees carry 22–191× (median 36×) more nodes than the underlying TermDag; `:dag` shrinks responses 8–23× in bytes (median 12×, 9.5 MB → 0.41 MB worst case) and is validated byte-equivalent after substitution.

End-to-end these three (with the Herbie-side changes in herbie-fp/herbie#1646) take Herbie's egglog backend from 6.1× slower than egg to 1.24× on bench/numerics (74.3 s vs 60.0 s), with slightly better accuracy than egg on that suite.

## Notes

- Without the new tags/options, `back-off` behaves as before except that egglog now applies matches per rule (see egraphs-good/egglog#1005); all existing tests pass unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

