### PR TITLE
Speed up greedy-DAG discovery by 1.5x and simplify it

### DIFF
--- a/src/greedy_dag_extract.rs
+++ b/src/greedy_dag_extract.rs
@@ -76,6 +76,9 @@ pub(crate) fn split_trailing_extractor(args: &[Expr]) -> Result<(&[Expr], bool),
 // `.agents/logs/2026-06-24-greedy-dag-extractor-perf.md` records the local
 // profiling data behind the representation choices below.
 
+/// A constructor's name and its input sorts.
+type Constructor = (String, Vec<ArcSort>);
+
 /// Once-paid dependency costs for one potential extracted DAG.
 ///
 /// The keys are reachable `(sort, value)` dependencies and the values are their
@@ -288,26 +291,9 @@ struct ReachableExtractionBuilder {
     structural_nodes: HashMap<InternId<DagCostKey>, (ArcSort, Value)>,
     /// Deduplication set for reachable eq-sort values.
     seen_eq_values: HashSet<InternId<DagCostKey>>,
-}
-
-/// One pending step in root-reachable producer discovery.
-///
-/// Producer-row tasks let the iterative traversal preserve the old recursive
-/// depth-first ordering: record a row, discover all of its children, then move
-/// to the next row. Producer ids break equal-cost ties, so this order is part
-/// of extraction's deterministic behavior.
-enum DiscoveryTask {
-    Node {
-        sort: ArcSort,
-        value: Value,
-    },
-    ProducerRows {
-        func_name: String,
-        input_sorts: Vec<ArcSort>,
-        rows: Vec<Vec<Value>>,
-        eclass: Value,
-        target: InternId<DagCostKey>,
-    },
+    /// Constructors by output sort name, in `functions_iter()` order, computed
+    /// once from the whole e-graph before traversal starts.
+    constructors_by_sort: HashMap<String, Arc<[Constructor]>>,
 }
 
 impl ReachableExtractionBuilder {
@@ -342,125 +328,66 @@ impl ReachableExtractionBuilder {
     }
 
     fn discover_node(&mut self, egraph: &EGraph, sort: &ArcSort, value: Value) {
-        let mut pending = vec![DiscoveryTask::Node {
-            sort: sort.clone(),
-            value,
-        }];
+        let key = self.intern_key(sort.name(), value);
 
-        while let Some(task) = pending.pop() {
-            match task {
-                DiscoveryTask::Node { sort, value } => {
-                    let sort_name = sort.name().to_owned();
-                    let key = self.intern_key(&sort_name, value);
+        if !sort.is_eq_sort() {
+            self.structural_nodes
+                .entry(key)
+                .or_insert_with(|| (sort.clone(), value));
+        }
 
-                    if !sort.is_eq_sort() {
-                        self.structural_nodes
-                            .entry(key)
-                            .or_insert_with(|| (sort.clone(), value));
-                    }
+        if sort.is_container_sort() {
+            for (child_sort, child_value) in egraph.container_inner_values(sort, value) {
+                self.discover_node(egraph, &child_sort, child_value);
+            }
+            return;
+        }
 
-                    if sort.is_container_sort() {
-                        for (child_sort, child_value) in egraph
-                            .container_inner_values(&sort, value)
-                            .into_iter()
-                            .rev()
-                        {
-                            pending.push(DiscoveryTask::Node {
-                                sort: child_sort,
-                                value: child_value,
-                            });
+        if !sort.is_eq_sort() || !self.seen_eq_values.insert(key) {
+            return;
+        }
+
+        let Some(constructors) = self.constructors_by_sort.get(sort.name()).cloned() else {
+            return;
+        };
+
+        for (func_name, input_sorts) in constructors.iter() {
+            let mut rows = Vec::new();
+            egraph
+                .read(|rs| {
+                    rs.constructor_enodes_for_eclass(func_name, value, |enode| {
+                        if !enode.subsumed {
+                            rows.push(enode.children.to_vec());
                         }
-                        continue;
-                    }
+                    })
+                })
+                .expect("constructor name came from the egraph");
 
-                    if !sort.is_eq_sort() || !self.seen_eq_values.insert(key) {
-                        continue;
-                    }
-
-                    let constructors: Vec<_> = egraph
-                        .functions_iter()
-                        .filter(|(_, func)| {
-                            func.func_type().subtype == FunctionSubtype::Constructor
-                                && !func.is_hidden()
-                                && !func.is_unextractable()
-                                && func.func_type().output.name() == sort_name
-                        })
-                        .map(|(func_name, func)| {
-                            (func_name.clone(), func.func_type().input.clone())
-                        })
-                        .collect();
-
-                    let mut producer_tasks = Vec::new();
-                    for (func_name, input_sorts) in constructors {
-                        let mut rows = Vec::new();
-                        egraph
-                            .read(|rs| {
-                                rs.constructor_enodes_for_eclass(&func_name, value, |enode| {
-                                    if !enode.subsumed {
-                                        rows.push(enode.children.to_vec());
-                                    }
-                                })
-                            })
-                            .expect("constructor name came from the egraph");
-
-                        rows.reverse();
-                        if !rows.is_empty() {
-                            producer_tasks.push(DiscoveryTask::ProducerRows {
-                                func_name,
-                                input_sorts,
-                                rows,
-                                eclass: value,
-                                target: key,
-                            });
-                        }
-                    }
-                    pending.extend(producer_tasks.into_iter().rev());
-                }
-                DiscoveryTask::ProducerRows {
-                    func_name,
-                    input_sorts,
-                    mut rows,
-                    eclass,
-                    target,
-                } => {
-                    let children = rows.pop().unwrap();
-                    let mut child_nodes = Vec::with_capacity(children.len());
-                    let mut dependencies = HashSet::default();
-                    for (child_value, child_sort) in children.iter().zip(input_sorts.iter()) {
-                        self.intern_nested_eq_dependencies(
-                            egraph,
-                            child_sort,
-                            *child_value,
-                            &mut dependencies,
-                        );
-                        child_nodes.push((child_sort.clone(), *child_value));
-                    }
-                    self.producer_rows.push(
-                        GreedyDagProducerRow {
-                            func_name: func_name.clone(),
-                            children,
-                            eclass,
-                            cost: (),
-                        },
-                        target,
-                        dependencies,
+            for children in rows {
+                let mut child_nodes = Vec::with_capacity(children.len());
+                let mut dependencies = HashSet::default();
+                for (child_value, child_sort) in children.iter().zip(input_sorts.iter()) {
+                    self.intern_nested_eq_dependencies(
+                        egraph,
+                        child_sort,
+                        *child_value,
+                        &mut dependencies,
                     );
+                    child_nodes.push((child_sort.clone(), *child_value));
+                }
+                self.producer_rows.push(
+                    GreedyDagProducerRow {
+                        func_name: func_name.clone(),
+                        children,
+                        eclass: value,
+                        cost: (),
+                    },
+                    key,
+                    dependencies,
+                );
 
-                    if !rows.is_empty() {
-                        pending.push(DiscoveryTask::ProducerRows {
-                            func_name,
-                            input_sorts,
-                            rows,
-                            eclass,
-                            target,
-                        });
-                    }
-                    for (child_sort, child_value) in child_nodes.into_iter().rev() {
-                        pending.push(DiscoveryTask::Node {
-                            sort: child_sort,
-                            value: child_value,
-                        });
-                    }
+                for (child_sort, child_value) in child_nodes {
+                    self.discover_node(egraph, &child_sort, child_value);
                 }
             }
         }
@@ -477,6 +404,19 @@ impl<C: MonoidCost> GreedyDagExtractor<C> {
         // Build the root-local problem: collect extractable functions, intern
         // reachable `(sort, value)` dependencies, and record producer rows with
         // their reverse dependency edges.
+        let mut constructors_by_sort: HashMap<String, Vec<Constructor>> = HashMap::default();
+        for (func_name, func) in egraph.functions_iter() {
+            if func.func_type().subtype == FunctionSubtype::Constructor
+                && !func.is_hidden()
+                && !func.is_unextractable()
+            {
+                constructors_by_sort
+                    .entry(func.func_type().output.name().to_owned())
+                    .or_default()
+                    .push((func_name.clone(), func.func_type().input.clone()));
+            }
+        }
+
         let mut builder = ReachableExtractionBuilder {
             sort_ids: Default::default(),
             key_ids: Default::default(),
@@ -486,6 +426,10 @@ impl<C: MonoidCost> GreedyDagExtractor<C> {
             },
             structural_nodes: Default::default(),
             seen_eq_values: Default::default(),
+            constructors_by_sort: constructors_by_sort
+                .into_iter()
+                .map(|(sort, funcs)| (sort, funcs.into()))
+                .collect(),
         };
 
         for (sort, value) in roots {


### PR DESCRIPTION
Follow-up to #55, targeting `codex/greedy-dag-extractor` so it can be merged into that branch before #55 lands.

Came out of a review of #55 focused on over-design and redundant code. Two of the findings turned out to be the same hot spot in `discover_node`, and fixing them makes greedy-DAG extraction **1.50x faster while deleting 56 lines**.

## What was slow

Discovery did two wasteful things per newly reachable eq-sort value:

1. **Rescanned every function in the e-graph** to find constructors whose output sort matches. On the Taylor 51 greedy-DAG canary that is 2010 functions scanned 7775 times — about 15.6M function checks where ~659K would do.
2. **Rebuilt an owned `Vec<(String, Vec<ArcSort>)>` on every visit**, cloning constructor names and input-sort vectors each time.

The second one turned out to be the bigger cost, and it is the part the review initially missed by reasoning about the scan's asymptotics alone. Fixing only the scan gets 1.16x; also sharing each sort's constructor list as an `Arc<[Constructor]>`, so a repeat visit clones a pointer, gets 1.50x.

## What changed

- Index constructors by output sort name **once per extraction**, built in `functions_iter()` order so producer-row discovery order — and the extraction tie-breaks that depend on it — are unchanged.
- Store each sort's list as `Arc<[Constructor]>`; `discover_node` clones the `Arc` instead of the contents.
- Replace the `DiscoveryTask` worklist with **plain recursion**. The paired `.rev()` calls existed only to make a LIFO stack reproduce DFS order, which recursion gives directly.

On the recursion: `seen_eq_values` already visits each eq-sort value once, so depth tracks term structure rather than DAG size. Instrumented, the deepest recursion on the Taylor canary is **14**. The other three traversals over the same reachable-value graph in this file were already plain recursive functions, so this also makes discovery consistent with them.

## Numbers

`hyperfine --warmup 3 --runs 15`, release build, 324 extractions:

| | before | after | |
|---|---|---|---|
| greedy-DAG | 593.4 ms ± 7.4 ms | **395.4 ms ± 5.9 ms** | **1.50 ± 0.03x faster** |
| tree (same file) | 2.266 s ± 0.052 s | 2.269 s ± 0.011 s | unchanged, as expected |

A control binary rebuilt from unmodified source measured within 0.45% of baseline (σ ≈ 1.5%), so the effect is far outside noise.

## Correctness

- Extraction output is **byte-identical** to before — all 972 lines of stdout on the Taylor canary, diffed. This is the check that matters most here, since the risk in both changes is perturbing discovery order and thus equal-cost tie-breaks.
- `cargo test --test integration_test`: 55/55 pass, including every `test_greedy_dag_*` case (cost-once-per-node, nested container deps, variant ranking, cycle avoidance, producer-snapshot consistency, conflicting-child reconciliation).
- `cargo test`: 44 of 46 passing when I stopped it. `tests/files.rs` is valuable here because it runs every checked-in `.egg` file through *both* extractors, but the last two cases (`python_array_optimize_old`, `stresstest_large_expr_old`) run very large programs in a debug build and had not finished after ~30 min. **Please let CI complete that run** — I did not observe those two to completion.
- `cargo fmt --check` and `cargo clippy --all-targets` are clean.

## Note on reproducing the benchmark

`.agents/logs/2026-06-24-greedy-dag-extractor-perf.md` (Experiment 37) cites `tests/taylor51.egg` and `tests/greedy-dag-taylor.egg` as checked in, but neither is on this branch. `taylor51.egg` is in core egglog (`tests/taylor51.egg`); the greedy-DAG variant does not exist in any egglog or egglog-experimental ref, so I regenerated it with:

```
sed -E 's/^\(extract (.*) ([0-9]+)\)$/(extract \1 \2 :extractor greedy-dag)/' \
    taylor51.egg > greedy-dag-taylor.egg
```

Might be worth checking that file in so the canary is reproducible.

## Other review findings, not addressed here

Kept out of this PR to keep it reviewable. Happy to open separate issues:

- **`:extractor` collides with ordinary arguments.** `split_trailing_extractor` scans for the first `Expr::Var` equal to `:extractor` anywhere in the arg list. `:extractor` is not reserved, so `(let :extractor "t1") (keep-best :extractor "t2")` fails with `extractor name must be a symbol`. Reachable but low frequency; a robust fix probably needs the name reserved at parser level, the way `INTERNAL_SYMBOL_PREFIX` reserves `@`.
- **`keep-best`'s default cost model changed** from `TreeAdditiveCostModel::default()` to `DynamicCostModel`, so it now honors `set-cost`/`with-dynamic-cost` without any opt-in. Not in `CHANGELOG.md`.
- **`rescore_producer_plan`'s per-call cache is load-bearing** and should not be hoisted. Keying it on `(sort, value)` across calls is unsound: `producer_choices` is rebuilt per call from `best_candidates` snapshots that mutate as the fixed point converges, and instrumentation on a conflict-heavy DAG found 151 cases where one key legitimately resolves to different producer rows in different calls. Worth a one-line comment recording that, since it reads like a missed optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
