### PR TITLE
Stop :extractor from consuming ordinary arguments

### DIFF
--- a/src/greedy_dag_extract.rs
+++ b/src/greedy_dag_extract.rs
@@ -19,35 +19,37 @@ use hashbrown::{HashMap, hash_map::Entry};
 use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 
+/// `:extractor` is an ordinary identifier, so user-defined commands receive it
+/// as a plain [`Expr::Var`] positional argument like any other name. Only the
+/// trailing `:extractor <symbol>` pair is read as the selector, so a value that
+/// happens to be named `:extractor` elsewhere in the argument list, or a
+/// non-symbol final argument, stays positional.
+///
+/// A trailing `<symbol> <symbol>` pair remains ambiguous and resolves to the
+/// selector, which also keeps a misspelled extractor name an error rather than
+/// silently positional. Removing that last case needs a surface form ordinary
+/// `Expr::Var` parsing cannot produce.
 pub(crate) fn split_trailing_extractor(args: &[Expr]) -> Result<(&[Expr], bool), Error> {
-    let Some(idx) = args
-        .iter()
-        .position(|arg| matches!(arg, Expr::Var(_, keyword) if keyword == ":extractor"))
-    else {
+    let Some([keyword, extractor]) = args.last_chunk::<2>() else {
         return Ok((args, false));
     };
 
-    if idx + 2 != args.len() {
+    if !matches!(keyword, Expr::Var(_, keyword) if keyword == ":extractor") {
+        return Ok((args, false));
+    }
+
+    let Expr::Var(_, name) = extractor else {
+        return Ok((args, false));
+    };
+
+    if name != "greedy-dag" {
         return Err(Error::ParseError(ParseError(
-            args[idx].span(),
-            "expected trailing :extractor <name>".into(),
+            extractor.span(),
+            format!("unknown extractor: {name}; omit :extractor to use the default tree extractor"),
         )));
     }
 
-    let extractor = &args[idx + 1];
-    let use_greedy_dag = match extractor {
-        Expr::Var(_, name) if name == "greedy-dag" => Ok(true),
-        Expr::Var(_, name) => Err(Error::ParseError(ParseError(
-            extractor.span(),
-            format!("unknown extractor: {name}; omit :extractor to use the default tree extractor"),
-        ))),
-        _ => Err(Error::ParseError(ParseError(
-            extractor.span(),
-            "extractor name must be a symbol".into(),
-        ))),
-    }?;
-
-    Ok((&args[..idx], use_greedy_dag))
+    Ok((&args[..args.len() - 2], true))
 }
 
 // Greedy-DAG extraction.
@@ -634,6 +636,14 @@ impl<C: MonoidCost> GreedyDagExtractor<C> {
     }
 
     /// Recompute the exact paid closure for a reconciled producer plan.
+    ///
+    /// The cache lives for one call and is intentionally not hoisted across
+    /// calls. Results are keyed by `(sort, value)` but decided by this call's
+    /// `producer_choices`, which `candidate_from_children` rebuilds per call
+    /// from `best_candidates` snapshots that keep changing until the fixed
+    /// point converges. Two calls in one run can therefore resolve the same key
+    /// to different producer rows, so a shared cache would score a plan against
+    /// choices it did not make.
     fn rescore_producer_plan(
         &self,
         egraph: &EGraph,

--- a/src/secondary_map.rs
+++ b/src/secondary_map.rs
@@ -11,9 +11,17 @@
 //! monoid aggregate. `slotmap` provides generational deletion safety we do not
 //! need and its `SparseSecondaryMap` is `HashMap`-backed; `rustc_index` and
 //! `index_vec` cover dense typed indexing, but not sparse associated payloads
-//! with an aggregate. See:
+//! with an aggregate. `indexmap::IndexSet` (already in the tree, via core's
+//! `TermDag`) does cover the interner half, and swapping it in measures the
+//! same on the Taylor greedy-DAG canary. It is not used because it would
+//! replace only that half: the id-indexed structures here are the point.
+//! `SecondaryMap` indexes a `Vec` directly and `SecondarySet` a bitset, both
+//! without hashing at all, and `AggregatedSparseSecondaryMap` maintains a
+//! running monoid total on insert so cost comparison never re-sums or
+//! subtracts. See:
 //! <https://docs.rs/lasso/latest/lasso/trait.IntoReader.html>,
-//! <https://docs.rs/slotmap/latest/slotmap/struct.SparseSecondaryMap.html> and
+//! <https://docs.rs/slotmap/latest/slotmap/struct.SparseSecondaryMap.html>,
+//! <https://docs.rs/indexmap/latest/indexmap/set/struct.IndexSet.html> and
 //! <https://doc.rust-lang.org/beta/nightly-rustc/rustc_index/vec/struct.IndexVec.html>.
 
 use egglog::extract::MonoidCost;

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -161,11 +161,12 @@ struct ExtractCheck {
 fn extract_command_parts(command: &Command) -> Option<ExtractCheck> {
     match command {
         Command::UserDefined(_, name, args) if name == "extract" => {
-            let use_greedy_dag = args
-                .iter()
-                .any(|arg| matches!(arg, Expr::Var(_, keyword) if keyword == ":extractor"));
+            let use_greedy_dag = matches!(
+                args.last_chunk::<2>(),
+                Some([Expr::Var(_, keyword), Expr::Var(..)]) if keyword == ":extractor"
+            );
             let positional = if use_greedy_dag {
-                args.get(..args.len().checked_sub(2)?)?
+                args.get(..args.len() - 2)?
             } else {
                 args
             };

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1780,3 +1780,67 @@ fn test_schedule_commands_and_actions() {
         )
         .unwrap();
 }
+
+#[test]
+fn test_extractor_keyword_does_not_shadow_a_value_named_extractor() {
+    // `:extractor` is a legal identifier, so a value may be bound to it.
+    let mut egraph = egglog_experimental::new_experimental_egraph();
+    let result = egraph
+        .parse_and_run_program(
+            None,
+            r#"
+            (relation table1 (i64))
+            (relation table2 (i64))
+            (table1 1)
+            (table2 2)
+            (let :extractor "table1")
+            (keep-best :extractor "table2")"#,
+        )
+        .expect("a table name bound to `:extractor` is positional, not the selector");
+    assert!(result.is_empty(), "unexpected output: {result:?}");
+}
+
+#[test]
+fn test_extractor_keyword_does_not_shadow_a_term_named_extractor() {
+    let result =
+        run_dynamic_dag("(let :extractor (Leaf 1))\n(multi-extract 1 :extractor (Leaf 2))");
+    assert_eq!(result.len(), 1);
+}
+
+/// A trailing `<symbol> <symbol>` pair is genuinely ambiguous: it is
+/// indistinguishable from the selector without changing the surface syntax.
+/// The selector wins, so a value named `:extractor` cannot be the
+/// second-to-last argument when the last one is also a bare symbol.
+#[test]
+fn test_extractor_keyword_wins_against_a_trailing_symbol_pair() {
+    let err = egglog_experimental::new_experimental_egraph()
+        .parse_and_run_program(
+            None,
+            &format!("{DYNAMIC_DAG_FIXTURE}\n(let :extractor (Leaf 1))\n(multi-extract 1 :extractor daggy)"),
+        )
+        .expect_err("documented limitation");
+    assert!(
+        err.to_string().contains("unknown extractor: daggy"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_extractor_keyword_does_not_shadow_a_variant_count_named_extractor() {
+    let result = run_dynamic_dag("(let :extractor 2)\n(extract daggy :extractor)");
+    assert_eq!(result.len(), 1);
+}
+
+#[test]
+fn test_unknown_trailing_extractor_is_still_rejected() {
+    let err = egglog_experimental::new_experimental_egraph()
+        .parse_and_run_program(
+            None,
+            &format!("{DYNAMIC_DAG_FIXTURE}\n(extract daggy :extractor greedy-dg)"),
+        )
+        .expect_err("a misspelled extractor name must not be treated as positional");
+    assert!(
+        err.to_string().contains("unknown extractor: greedy-dg"),
+        "unexpected error: {err}"
+    );
+}


### PR DESCRIPTION
Second follow-up to #55, targeting `codex/greedy-dag-extractor`. Independent of #64 (the perf one) — they touch different code and can land in either order.

## The bug

`split_trailing_extractor` scanned the **whole** argument list for the first `Expr::Var` equal to `:extractor`. But `:extractor` is not reserved anywhere else: `parse_expr` turns any bare atom into an `Expr::Var`, the `:key val` option syntax only applies to built-in commands, and `keep-best` / `multi-extract` / `extract` are all user-defined commands whose arguments arrive as plain exprs. So a value legitimately named `:extractor` got consumed as the selector:

```
(relation table1 (i64))
(relation table2 (i64))
(let :extractor "table1")
(keep-best :extractor "table2")
```
```
Err(ParseError(In 7:31-38: "table2", "extractor name must be a symbol"))
```

The same program with the variable renamed to `t1` works. Reachable at all three call sites — a table name in `keep-best`, a term in `multi-extract`, a variant count in `extract`. The existing `idx + 2 != args.len()` guard did not help: in the natural cases the offending variable already *is* second-to-last.

## The fix

Match only the trailing `:extractor <symbol>` pair, and require the trailing name to be a symbol. A non-symbol final argument (a string literal, a call) means this was never the selector, so it stays positional. That covers all three cases above.

Deliberately kept: a misspelled name like `:extractor greedy-dg` is still an error rather than silently reinterpreted as positional arguments.

**Known limitation, documented in the code:** a trailing `<symbol> <symbol>` pair is genuinely ambiguous and still resolves to the selector, so a value named `:extractor` cannot be second-to-last when the last argument is also a bare symbol. Removing that case needs a surface form ordinary `Expr::Var` parsing cannot produce (e.g. a trailing `(:extractor greedy-dag)` call), which changes the syntax — out of scope here. There is a test asserting this behavior so the trade-off is explicit rather than accidental.

`tests/files.rs` had its own copy of the same "scan anywhere" detection; fixed the same way.

## Also in here

Two conclusions from the same review, recorded so they don't get re-litigated. Both are comments only:

- **`rescore_producer_plan`'s per-call cache is load-bearing, not a missed optimization.** Results are keyed by `(sort, value)` but decided by that call's `producer_choices`, which `candidate_from_children` rebuilds per call from `best_candidates` snapshots that keep changing until the fixed point converges. On a conflict-heavy diamond DAG, instrumentation found **151 cases** where one key legitimately resolves to different producer rows in different calls within a single run — so hoisting the cache would score a plan against choices it did not make. It looks hoistable (74% of node visits are redundant), which is exactly why it deserves the note.
- **`secondary_map.rs`'s module doc** justified rejecting slotmap / lasso / rustc_index but never `indexmap`, the one that actually overlaps. I tried the swap: `IndexSet` covers the interner half and measures the same on the Taylor canary, but it replaces only that half and the net change is +4 lines. The id-indexed structures are the point — `SecondaryMap` indexes a `Vec` directly, `SecondarySet` a bitset, neither hashing at all, and `AggregatedSparseSecondaryMap` keeps a running monoid total. Doc now says so.

## Verification

- `cargo test --test integration_test`: 60/60, including 4 new regression tests covering each reachable collision plus the documented ambiguous case and the misspelling.
- Extraction output **byte-identical** to before on the Taylor canary, for both greedy-DAG and tree extraction (972 and 324 lines respectively) — this is a parsing change only.
- `cargo fmt --check` and `cargo clippy --all-targets` clean.
- I did not run the full `cargo test` to completion; `tests/files.rs`'s last two cases run very large programs in a debug build. Please let CI cover those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
